### PR TITLE
chore: validate package-lock.json sync in release workflow

### DIFF
--- a/.github/workflows/npm-publish-npm-packages.yml
+++ b/.github/workflows/npm-publish-npm-packages.yml
@@ -15,6 +15,10 @@ jobs:
       - uses: actions/setup-node@v4
         with:
           node-version: 20
+      - name: Validate lockfile
+        run: |
+          npm install --package-lock-only
+          git diff --exit-code package-lock.json || (echo "package-lock.json is out of sync. Run 'npm install' and commit the changes." && exit 1)
       - run: npm ci
       - run: npm run build
       - run: npm test


### PR DESCRIPTION
Adds lockfile synchronization validation to the npm publish workflow to ensure reproducible installs.

Validates that `package-lock.json` is synchronized with `package.json` before building and publishing the package. This prevents releases with mismatched dependencies that could lead to non-reproducible installations.

**Changes:**
- Added validation step in `build` job before `npm ci`
- Executes `npm install --package-lock-only` and checks for lockfile modifications
- Fails fast with clear error message if lockfile is out of sync