### PR TITLE
feat: add StreamOptions support for orchestration streaming

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1205,22 +1205,25 @@ streaming responses. Only available with the Orchestration API.
 **Example:**
 
 ```typescript
-import { buildTranslationConfig } from "@jerome-benoit/sap-ai-provider";
+import { createSAPAIProvider, buildTranslationConfig } from "@jerome-benoit/sap-ai-provider";
+import { streamText } from "ai";
+
+const provider = createSAPAIProvider();
+
+// Configure stream options at model level
+const model = provider("gpt-4o", {
+  translation: {
+    output: buildTranslationConfig("output", { targetLanguage: "de" }),
+  },
+  streamOptions: {
+    chunkSize: 50,
+    delimiters: [".", "!", "?"],
+  },
+});
 
 const result = await streamText({
-  model: sapai("gpt-4o"),
-  prompt: "Translate this to German",
-  providerOptions: {
-    sapai: {
-      translation: {
-        output: buildTranslationConfig("output", { targetLanguage: "de" }),
-      },
-      streamOptions: {
-        chunkSize: 50,
-        delimiters: [".", "!", "?"],
-      },
-    },
-  },
+  model,
+  prompt: "Explain AI in simple terms",
 });
 ```
 

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1191,7 +1191,7 @@ console.log("Response:", result.text);
 
 ### `OrchestrationStreamOptions`
 
-Stream options for controlling how post-LLM modules (translation, masking) process
+Stream options for controlling how post-LLM modules (translation, masking, filtering) process
 streaming responses. Only available with the Orchestration API.
 
 **Properties:**

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -54,6 +54,7 @@ consistently:
   - [`SAPAIProviderSettings`](#sapaiprovidersettings)
   - [`SAPAISettings`](#sapaisettings)
   - [`ModelParams`](#modelparams)
+  - [`OrchestrationStreamOptions`](#orchestrationstreamoptions)
   - [`SAPAIServiceKey`](#sapaiservicekey)
   - [`MaskingModuleConfig`](#maskingmoduleconfig)
   - [`DpiConfig`](#dpiconfig)
@@ -1195,22 +1196,24 @@ streaming responses. Only available with the Orchestration API.
 
 **Properties:**
 
-| Property                 | Type       | Default | Description                                                   |
-| ------------------------ | ---------- | ------- | ------------------------------------------------------------- |
-| `chunkSize`              | `number`   | -       | Number of tokens to buffer before processing post-LLM modules |
-| `delimiters`             | `string[]` | -       | Sentence delimiters for chunking (e.g., `[".", "!", "?"]`)    |
-| `outputFilteringOverlap` | `number`   | -       | Token overlap for output filtering context                    |
+| Property                 | Type                | Description                                                            |
+| ------------------------ | ------------------- | ---------------------------------------------------------------------- |
+| `chunkSize`              | `number`            | Characters to buffer before post-LLM processing (range: 1-10000)       |
+| `delimiters`             | `readonly string[]` | Sentence delimiters for chunking (e.g., `[".", "!", "?"]`)             |
+| `outputFilteringOverlap` | `number`            | Characters from previous chunks for filtering context (range: 0-10000) |
 
 **Example:**
 
 ```typescript
+import { buildTranslationConfig } from "@jerome-benoit/sap-ai-provider";
+
 const result = await streamText({
   model: sapai("gpt-4o"),
   prompt: "Translate this to German",
   providerOptions: {
     sapai: {
       translation: {
-        output_language: "de",
+        output: buildTranslationConfig("output", { targetLanguage: "de" }),
       },
       streamOptions: {
         chunkSize: 50,

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1041,6 +1041,7 @@ Model-specific configuration options.
 | `masking`                    | `MaskingModule`              | -       | Data masking configuration (DPI)                         |
 | `filtering`                  | `FilteringModule`            | -       | Content filtering configuration                          |
 | `grounding`                  | `GroundingModule`            | -       | Document grounding configuration                         |
+| `translation`                | `TranslationModule`          | -       | Translation configuration (Orchestration only)           |
 | `placeholderValues`          | `Record<string, string>`     | -       | Default values for template placeholders                 |
 | `promptTemplateRef`          | `PromptTemplateRef`          | -       | Reference to a Prompt Registry template                  |
 | `responseFormat`             | `ResponseFormatConfig`       | -       | Response format specification                            |

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1212,7 +1212,7 @@ import { streamText } from "ai";
 const provider = createSAPAIProvider();
 
 // Configure stream options at model level
-const model = provider("gpt-4o", {
+const model = provider("gpt-4.1", {
   translation: {
     output: buildTranslationConfig("output", { targetLanguage: "de" }),
   },

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1031,19 +1031,20 @@ Model-specific configuration options.
 
 **Properties:**
 
-| Property                     | Type                     | Default | Description                                      |
-| ---------------------------- | ------------------------ | ------- | ------------------------------------------------ |
-| `modelVersion`               | `string`                 | -       | Specific model version                           |
-| `includeReasoning`           | `boolean`                | `false` | Include reasoning parts in SAP prompt conversion |
-| `escapeTemplatePlaceholders` | `boolean`                | `true`  | Escape template delimiters to prevent conflicts  |
-| `modelParams`                | `ModelParams`            | -       | Model generation parameters                      |
-| `masking`                    | `MaskingModule`          | -       | Data masking configuration (DPI)                 |
-| `filtering`                  | `FilteringModule`        | -       | Content filtering configuration                  |
-| `grounding`                  | `GroundingModule`        | -       | Document grounding configuration                 |
-| `placeholderValues`          | `Record<string, string>` | -       | Default values for template placeholders         |
-| `promptTemplateRef`          | `PromptTemplateRef`      | -       | Reference to a Prompt Registry template          |
-| `responseFormat`             | `ResponseFormatConfig`   | -       | Response format specification                    |
-| `tools`                      | `ChatCompletionTool[]`   | -       | Tool definitions in SAP AI SDK format            |
+| Property                     | Type                         | Default | Description                                              |
+| ---------------------------- | ---------------------------- | ------- | -------------------------------------------------------- |
+| `modelVersion`               | `string`                     | -       | Specific model version                                   |
+| `includeReasoning`           | `boolean`                    | `false` | Include reasoning parts in SAP prompt conversion         |
+| `escapeTemplatePlaceholders` | `boolean`                    | `true`  | Escape template delimiters to prevent conflicts          |
+| `modelParams`                | `ModelParams`                | -       | Model generation parameters                              |
+| `masking`                    | `MaskingModule`              | -       | Data masking configuration (DPI)                         |
+| `filtering`                  | `FilteringModule`            | -       | Content filtering configuration                          |
+| `grounding`                  | `GroundingModule`            | -       | Document grounding configuration                         |
+| `placeholderValues`          | `Record<string, string>`     | -       | Default values for template placeholders                 |
+| `promptTemplateRef`          | `PromptTemplateRef`          | -       | Reference to a Prompt Registry template                  |
+| `responseFormat`             | `ResponseFormatConfig`       | -       | Response format specification                            |
+| `streamOptions`              | `OrchestrationStreamOptions` | -       | Stream options for post-LLM modules (Orchestration only) |
+| `tools`                      | `ChatCompletionTool[]`       | -       | Tool definitions in SAP AI SDK format                    |
 
 **Example:**
 
@@ -1082,7 +1083,7 @@ For type-safe API-specific configuration, use the discriminated union types:
 
 - `OrchestrationModelSettings` - Settings with `api?: "orchestration"` and
   Orchestration-only options (`filtering`, `masking`, `grounding`, `translation`,
-  `tools`, `escapeTemplatePlaceholders`)
+  `tools`, `streamOptions`, `escapeTemplatePlaceholders`)
 - `FoundationModelsModelSettings` - Settings with `api: "foundation-models"` and
   Foundation Models-only options (`dataSources`)
 
@@ -1184,6 +1185,45 @@ console.log("Response:", result.text);
 > **Note:** Using these parameters with Orchestration API (`api: "orchestration"`)
 > will have no effect as they are passed through but ignored by the Orchestration
 > service.
+
+---
+
+### `OrchestrationStreamOptions`
+
+Stream options for controlling how post-LLM modules (translation, masking) process
+streaming responses. Only available with the Orchestration API.
+
+**Properties:**
+
+| Property                 | Type       | Default | Description                                                   |
+| ------------------------ | ---------- | ------- | ------------------------------------------------------------- |
+| `chunkSize`              | `number`   | -       | Number of tokens to buffer before processing post-LLM modules |
+| `delimiters`             | `string[]` | -       | Sentence delimiters for chunking (e.g., `[".", "!", "?"]`)    |
+| `outputFilteringOverlap` | `number`   | -       | Token overlap for output filtering context                    |
+
+**Example:**
+
+```typescript
+const result = await streamText({
+  model: sapai("gpt-4o"),
+  prompt: "Translate this to German",
+  providerOptions: {
+    sapai: {
+      translation: {
+        output_language: "de",
+      },
+      streamOptions: {
+        chunkSize: 50,
+        delimiters: [".", "!", "?"],
+      },
+    },
+  },
+});
+```
+
+> **Note:** When using translation with streaming, it is recommended to set
+> `delimiters` to ensure proper sentence boundary detection. The provider will
+> emit a warning if translation is configured without delimiters.
 
 ---
 

--- a/src/base-language-model-strategy.ts
+++ b/src/base-language-model-strategy.ts
@@ -143,7 +143,7 @@ export abstract class BaseLanguageModelStrategy<
       const idGenerator = new StreamIdGenerator();
       const responseId = idGenerator.generateResponseId();
 
-      const streamWarnings = this.collectStreamWarnings(settings);
+      const streamWarnings = this.collectStreamWarnings(settings, commonParts.sapOptions);
 
       const transformedStream = createStreamTransformer({
         convertToAISDKError,
@@ -242,14 +242,17 @@ export abstract class BaseLanguageModelStrategy<
 
   /**
    * Collects stream-specific warnings.
-   * Override in subclasses to add API-specific stream warnings.
+   * Override in subclasses to add API-specific streaming warnings.
    * @param _settings - Model settings (unused in base implementation).
+   * @param _sapOptions - Provider options (unused in base implementation).
    * @returns Array of warnings for streaming operations.
    * @internal
    */
   protected collectStreamWarnings(
     // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _settings: TSettings,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _sapOptions?: Record<string, unknown>,
   ): SharedV3Warning[] {
     return [];
   }

--- a/src/base-language-model-strategy.ts
+++ b/src/base-language-model-strategy.ts
@@ -137,10 +137,13 @@ export abstract class BaseLanguageModelStrategy<
         client,
         request,
         options.abortSignal ?? undefined,
+        settings,
       );
 
       const idGenerator = new StreamIdGenerator();
       const responseId = idGenerator.generateResponseId();
+
+      const streamWarnings = this.collectStreamWarnings(settings);
 
       const transformedStream = createStreamTransformer({
         convertToAISDKError,
@@ -155,7 +158,7 @@ export abstract class BaseLanguageModelStrategy<
         streamResponseGetTokenUsage: streamResponse.getTokenUsage,
         url: this.getUrl(),
         version: VERSION,
-        warnings: [...commonParts.warnings, ...warnings],
+        warnings: [...commonParts.warnings, ...warnings, ...streamWarnings],
       });
 
       return {
@@ -238,6 +241,20 @@ export abstract class BaseLanguageModelStrategy<
   ): { readonly request: TRequest; readonly warnings: SharedV3Warning[] };
 
   /**
+   * Collects stream-specific warnings.
+   * Override in subclasses to add API-specific stream warnings.
+   * @param _settings - Model settings (unused in base implementation).
+   * @returns Array of warnings for streaming operations.
+   * @internal
+   */
+  protected collectStreamWarnings(
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    _settings: TSettings,
+  ): SharedV3Warning[] {
+    return [];
+  }
+
+  /**
    * Creates the appropriate SDK client for this API.
    * @param config - Strategy configuration.
    * @param settings - Model settings.
@@ -270,6 +287,7 @@ export abstract class BaseLanguageModelStrategy<
    * @param client - SDK client instance.
    * @param request - Request body.
    * @param abortSignal - Optional abort signal.
+   * @param settings - Model settings for API-specific stream options.
    * @returns Stream response with accessors.
    * @internal
    */
@@ -277,6 +295,7 @@ export abstract class BaseLanguageModelStrategy<
     client: TClient,
     request: TRequest,
     abortSignal: AbortSignal | undefined,
+    settings: TSettings,
   ): Promise<StreamCallResponse>;
 
   /**

--- a/src/foundation-models-language-model-strategy.ts
+++ b/src/foundation-models-language-model-strategy.ts
@@ -128,7 +128,7 @@ export class FoundationModelsLanguageModelStrategy extends BaseLanguageModelStra
       getFinishReason: () => response.getFinishReason(),
       getTokenUsage: () => response.getTokenUsage(),
       getToolCalls: () => response.getToolCalls(),
-      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- SAP SDK types headers as any
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       rawResponse: { headers: response.rawResponse.headers },
     };
   }
@@ -137,7 +137,7 @@ export class FoundationModelsLanguageModelStrategy extends BaseLanguageModelStra
     client: FoundationModelsClient,
     request: AzureOpenAiChatCompletionParameters,
     abortSignal: AbortSignal | undefined,
-    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Required by base class signature
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
     _settings: FoundationModelsModelSettings,
   ): Promise<StreamCallResponse> {
     const streamResponse = await client.stream(request, abortSignal);

--- a/src/foundation-models-language-model-strategy.ts
+++ b/src/foundation-models-language-model-strategy.ts
@@ -137,6 +137,8 @@ export class FoundationModelsLanguageModelStrategy extends BaseLanguageModelStra
     client: FoundationModelsClient,
     request: AzureOpenAiChatCompletionParameters,
     abortSignal: AbortSignal | undefined,
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars -- Required by base class signature
+    _settings: FoundationModelsModelSettings,
   ): Promise<StreamCallResponse> {
     const streamResponse = await client.stream(request, abortSignal);
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -70,6 +70,7 @@ export type {
   OrchestrationDefaultSettings,
   OrchestrationModelParams,
   OrchestrationModelSettings,
+  OrchestrationStreamOptions,
   PromptTemplateRef,
   PromptTemplateRefByID,
   PromptTemplateRefByScenarioNameVersion,

--- a/src/orchestration-language-model-strategy.ts
+++ b/src/orchestration-language-model-strategy.ts
@@ -590,16 +590,17 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
     outputFiltering?: { overlap: number };
     promptTemplating: { include_usage: boolean };
   } {
-    const hasGlobalOptions =
-      streamOptions?.chunkSize !== undefined || streamOptions?.delimiters !== undefined;
+    const hasNonEmptyDelimiters =
+      Array.isArray(streamOptions?.delimiters) && streamOptions.delimiters.length > 0;
+    const hasGlobalOptions = streamOptions?.chunkSize !== undefined || hasNonEmptyDelimiters;
 
     return {
       promptTemplating: { include_usage: true },
       ...(hasGlobalOptions && {
         global: {
           ...(streamOptions.chunkSize !== undefined && { chunk_size: streamOptions.chunkSize }),
-          ...(streamOptions.delimiters !== undefined && {
-            delimiters: [...streamOptions.delimiters],
+          ...(hasNonEmptyDelimiters && {
+            delimiters: [...(streamOptions.delimiters as string[])],
           }),
         },
       }),

--- a/src/orchestration-language-model-strategy.ts
+++ b/src/orchestration-language-model-strategy.ts
@@ -323,7 +323,6 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
   ): SharedV3Warning[] {
     const warnings: SharedV3Warning[] = [];
 
-    // Warn if translation is configured but delimiters are not set
     if (settings.translation && hasKeys(settings.translation)) {
       if (!settings.streamOptions?.delimiters || settings.streamOptions.delimiters.length === 0) {
         warnings.push({

--- a/src/orchestration-language-model-strategy.ts
+++ b/src/orchestration-language-model-strategy.ts
@@ -323,6 +323,11 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
   ): SharedV3Warning[] {
     const warnings: SharedV3Warning[] = [];
 
+    // Skip warning if orchestrationConfigRef is set (local module settings are ignored)
+    if (settings.orchestrationConfigRef) {
+      return warnings;
+    }
+
     if (settings.translation && hasKeys(settings.translation)) {
       if (!settings.streamOptions?.delimiters || settings.streamOptions.delimiters.length === 0) {
         warnings.push({
@@ -590,17 +595,17 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
     outputFiltering?: { overlap: number };
     promptTemplating: { include_usage: boolean };
   } {
-    const hasNonEmptyDelimiters =
-      Array.isArray(streamOptions?.delimiters) && streamOptions.delimiters.length > 0;
+    const delimiters = streamOptions?.delimiters;
+    const hasNonEmptyDelimiters = Array.isArray(delimiters) && delimiters.length > 0;
     const hasGlobalOptions = streamOptions?.chunkSize !== undefined || hasNonEmptyDelimiters;
 
     return {
       promptTemplating: { include_usage: true },
       ...(hasGlobalOptions && {
         global: {
-          ...(streamOptions.chunkSize !== undefined && { chunk_size: streamOptions.chunkSize }),
+          ...(streamOptions?.chunkSize !== undefined && { chunk_size: streamOptions.chunkSize }),
           ...(hasNonEmptyDelimiters && {
-            delimiters: [...(streamOptions.delimiters as string[])],
+            delimiters: Array.from(delimiters),
           }),
         },
       }),

--- a/src/orchestration-language-model-strategy.ts
+++ b/src/orchestration-language-model-strategy.ts
@@ -315,16 +315,21 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
   /**
    * Collects stream-specific warnings for orchestration.
    * @param settings - Model settings.
+   * @param sapOptions - Provider options.
    * @returns Array of warnings for streaming operations.
    * @internal
    */
   protected override collectStreamWarnings(
     settings: OrchestrationModelSettings,
+    sapOptions?: Record<string, unknown>,
   ): SharedV3Warning[] {
     const warnings: SharedV3Warning[] = [];
 
-    // Skip warning if orchestrationConfigRef is set (local module settings are ignored)
-    if (settings.orchestrationConfigRef) {
+    // Skip warning if a valid orchestrationConfigRef is set in settings or providerOptions
+    // (local module settings are ignored when using server-side config)
+    const configRefCandidate =
+      sapOptions?.orchestrationConfigRef ?? settings.orchestrationConfigRef;
+    if (configRefCandidate && isOrchestrationConfigRef(configRefCandidate)) {
       return warnings;
     }
 

--- a/src/sap-ai-settings.ts
+++ b/src/sap-ai-settings.ts
@@ -128,8 +128,36 @@ export interface OrchestrationModelSettings {
   readonly placeholderValues?: Record<string, string>;
   readonly promptTemplateRef?: PromptTemplateRef;
   readonly responseFormat?: ResponseFormat;
+  /**
+   * Options for streaming behavior with post-LLM modules.
+   * Only applies when using `streamText()` with orchestration modules.
+   */
+  readonly streamOptions?: OrchestrationStreamOptions;
   readonly tools?: ChatCompletionTool[];
   readonly translation?: TranslationModule;
+}
+
+/**
+ * Stream options for orchestration post-LLM module processing.
+ * Controls chunking behavior for translation, filtering, and other modules during streaming.
+ */
+export interface OrchestrationStreamOptions {
+  /**
+   * Minimum number of characters per chunk for post-LLM modules.
+   * Valid range: 1-10000. Defaults to 100.
+   */
+  readonly chunkSize?: number;
+  /**
+   * Delimiters for splitting stream into chunks (e.g., sentence boundaries).
+   * Required when translation module is configured.
+   * @example ["\n", ".", "?", "!"]
+   */
+  readonly delimiters?: readonly string[];
+  /**
+   * Additional characters from previous chunks sent to output filtering for context.
+   * Valid range: 0-10000.
+   */
+  readonly outputFilteringOverlap?: number;
 }
 
 /** Reference to a template in SAP AI Core's Prompt Registry. */

--- a/src/sap-ai-settings.ts
+++ b/src/sap-ai-settings.ts
@@ -265,10 +265,13 @@ export interface SAPAISettings {
   readonly api?: SAPAIApiType;
   /** @default true */
   readonly escapeTemplatePlaceholders?: boolean;
+  /** Orchestration API only. */
   readonly filtering?: FilteringModule;
+  /** Orchestration API only. */
   readonly grounding?: GroundingModule;
   /** @default false */
   readonly includeReasoning?: boolean;
+  /** Orchestration API only. */
   readonly masking?: MaskingModule;
   readonly modelParams?: CommonModelParams;
   readonly modelVersion?: string;
@@ -279,7 +282,11 @@ export interface SAPAISettings {
   /** Orchestration API only. */
   readonly promptTemplateRef?: PromptTemplateRef;
   readonly responseFormat?: ResponseFormat;
+  /** Orchestration API only. */
+  readonly streamOptions?: OrchestrationStreamOptions;
+  /** Orchestration API only. */
   readonly tools?: ChatCompletionTool[];
+  /** Orchestration API only. */
   readonly translation?: TranslationModule;
 }
 

--- a/src/sap-ai-validation.ts
+++ b/src/sap-ai-validation.ts
@@ -152,6 +152,7 @@ const ORCHESTRATION_ONLY_FEATURE_KEYS = [
   "orchestrationConfigRef",
   "placeholderValues",
   "promptTemplateRef",
+  "streamOptions",
   "tools",
   "translation",
 ] as const;
@@ -170,6 +171,7 @@ const ORCHESTRATION_ONLY_FEATURES: Readonly<
   orchestrationConfigRef: "Orchestration config reference (orchestrationConfigRef)",
   placeholderValues: "Placeholder values (placeholderValues)",
   promptTemplateRef: "Prompt template reference (promptTemplateRef)",
+  streamOptions: "Stream options for post-LLM modules",
   tools: "SAP-format tool definitions (use AI SDK tools instead)",
   translation: "Translation",
 } as const;


### PR DESCRIPTION
## Summary
- Add `OrchestrationStreamOptions` interface with `chunkSize`, `delimiters`, and `outputFilteringOverlap`
- Pass stream options to SAP AI SDK in orchestration streaming calls
- Warn when translation is configured without delimiters

Closes #28