### PR TITLE
fix: defer tool-input-start until real tool call ID is available

### DIFF
--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -2558,6 +2558,10 @@ describe("SAPAILanguageModel", () => {
         (p): p is Extract<LanguageModelV3StreamPart, { type: "tool-input-start" }> =>
           p.type === "tool-input-start",
       );
+      const toolInputDeltas = parts.filter(
+        (p): p is Extract<LanguageModelV3StreamPart, { type: "tool-input-delta" }> =>
+          p.type === "tool-input-delta",
+      );
       const toolCall = parts.find(
         (p): p is Extract<LanguageModelV3StreamPart, { type: "tool-call" }> =>
           p.type === "tool-call",
@@ -2566,6 +2570,10 @@ describe("SAPAILanguageModel", () => {
       expect(toolInputStart).toBeDefined();
       expect(toolInputStart?.id).toMatch(uuidRegex);
       expect(toolInputStart?.toolName).toBe("no_id_tool");
+
+      expect(toolInputDeltas).toHaveLength(1);
+      expect(toolInputDeltas[0]?.id).toBe(toolInputStart?.id);
+      expect(toolInputDeltas[0]?.delta).toBe('{"x":1}');
 
       expect(toolCall).toBeDefined();
       expect(toolCall?.toolCallId).toMatch(uuidRegex);

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -2532,6 +2532,47 @@ describe("SAPAILanguageModel", () => {
       expect(toolCall?.input).toBe('{"a":"b"}');
     });
 
+    it("should generate a fallback UUID when tool call id is never provided by the API", async () => {
+      const uuidRegex = /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
+
+      await setStreamChunksForApi(api, [
+        createMockStreamChunk({
+          deltaToolCalls: [
+            {
+              function: { arguments: '{"x":1}', name: "no_id_tool" },
+              index: 0,
+            },
+          ],
+          finishReason: "tool_calls",
+          usage: { completion_tokens: 5, prompt_tokens: 3, total_tokens: 8 },
+        }),
+      ]);
+
+      const model = createModelForApi(api);
+      const prompt = createPrompt("test fallback id");
+
+      const { stream } = await model.doStream({ prompt });
+      const parts = await readAllStreamParts(stream);
+
+      const toolInputStart = parts.find(
+        (p): p is Extract<LanguageModelV3StreamPart, { type: "tool-input-start" }> =>
+          p.type === "tool-input-start",
+      );
+      const toolCall = parts.find(
+        (p): p is Extract<LanguageModelV3StreamPart, { type: "tool-call" }> =>
+          p.type === "tool-call",
+      );
+
+      expect(toolInputStart).toBeDefined();
+      expect(toolInputStart?.id).toMatch(uuidRegex);
+      expect(toolInputStart?.toolName).toBe("no_id_tool");
+
+      expect(toolCall).toBeDefined();
+      expect(toolCall?.toolCallId).toMatch(uuidRegex);
+      expect(toolCall?.toolCallId).toBe(toolInputStart?.id);
+      expect(toolCall?.input).toBe('{"x":1}');
+    });
+
     it("should handle Unicode and multi-byte characters in large streams without corruption", async () => {
       const unicodeContent =
         "Hello 世界! 🌍🌎🌏 Привет мир! مرحبا بالعالم " +

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -2401,6 +2401,72 @@ describe("SAPAILanguageModel", () => {
       expect(parsed2.query).toHaveLength(5000);
     });
 
+    it("should emit consistent tool call IDs when id arrives on a later chunk than function name (Vertex pattern)", async () => {
+      const realId = "vertex_tool_be5b294b-ece3-46f0-8b0d-22cd00000000";
+
+      await setStreamChunksForApi(api, [
+        createMockStreamChunk({
+          deltaToolCalls: [
+            {
+              function: { name: "query_bookings" },
+              index: 0,
+            },
+          ],
+        }),
+        createMockStreamChunk({
+          deltaToolCalls: [
+            {
+              function: { arguments: '{"customer":' },
+              id: realId,
+              index: 0,
+            },
+          ],
+        }),
+        createMockStreamChunk({
+          deltaToolCalls: [
+            {
+              function: { arguments: '"Acme"}' },
+              index: 0,
+            },
+          ],
+          finishReason: "tool_calls",
+          usage: { completion_tokens: 10, prompt_tokens: 5, total_tokens: 15 },
+        }),
+      ]);
+
+      const model = createModelForApi(api);
+      const prompt = createPrompt("show bookings");
+
+      const { stream } = await model.doStream({ prompt });
+      const parts = await readAllStreamParts(stream);
+
+      const toolInputStart = parts.find(
+        (p): p is Extract<LanguageModelV3StreamPart, { type: "tool-input-start" }> =>
+          p.type === "tool-input-start",
+      );
+      const toolInputDeltas = parts.filter(
+        (p): p is Extract<LanguageModelV3StreamPart, { type: "tool-input-delta" }> =>
+          p.type === "tool-input-delta",
+      );
+      const toolCall = parts.find(
+        (p): p is Extract<LanguageModelV3StreamPart, { type: "tool-call" }> =>
+          p.type === "tool-call",
+      );
+
+      expect(toolInputStart).toBeDefined();
+      expect(toolInputStart?.id).toBe(realId);
+      expect(toolInputStart?.toolName).toBe("query_bookings");
+
+      for (const delta of toolInputDeltas) {
+        expect(delta.id).toBe(realId);
+      }
+
+      expect(toolCall).toBeDefined();
+      expect(toolCall?.toolCallId).toBe(realId);
+      expect(toolCall?.toolName).toBe("query_bookings");
+      expect(toolCall?.input).toBe('{"customer":"Acme"}');
+    });
+
     it("should handle Unicode and multi-byte characters in large streams without corruption", async () => {
       const unicodeContent =
         "Hello 世界! 🌍🌎🌏 Привет мир! مرحبا بالعالم " +

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -2899,7 +2899,7 @@ describe("SAPAILanguageModel", () => {
         });
       });
 
-      it("should flush tool calls that never received input-start", async () => {
+      it("should emit tool-input-start when toolName arrives on a later chunk than id", async () => {
         await setStreamChunksForApi(api, [
           createMockStreamChunk({
             deltaToolCalls: [
@@ -2932,7 +2932,24 @@ describe("SAPAILanguageModel", () => {
         const { stream } = await model.doStream({ prompt });
         const parts = await readAllStreamParts(stream);
 
+        const toolInputStart = parts.find(
+          (p): p is Extract<LanguageModelV3StreamPart, { type: "tool-input-start" }> =>
+            p.type === "tool-input-start",
+        );
+        const toolInputDeltas = parts.filter(
+          (p): p is Extract<LanguageModelV3StreamPart, { type: "tool-input-delta" }> =>
+            p.type === "tool-input-delta",
+        );
         const toolCall = parts.find((p) => p.type === "tool-call");
+
+        expect(toolInputStart).toBeDefined();
+        expect(toolInputStart?.id).toBe("call_no_start");
+        expect(toolInputStart?.toolName).toBe("delayed_name");
+
+        expect(toolInputDeltas).toHaveLength(2);
+        expect(toolInputDeltas[0]?.delta).toBe('{"partial":');
+        expect(toolInputDeltas[1]?.delta).toBe('"value"}');
+
         expect(toolCall).toBeDefined();
         expect(toolCall).toEqual({
           input: '{"partial":"value"}',

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -2457,9 +2457,12 @@ describe("SAPAILanguageModel", () => {
       expect(toolInputStart?.id).toBe(realId);
       expect(toolInputStart?.toolName).toBe("query_bookings");
 
+      expect(toolInputDeltas).toHaveLength(2);
       for (const delta of toolInputDeltas) {
         expect(delta.id).toBe(realId);
       }
+      const concatenatedDeltas = toolInputDeltas.map((d) => d.delta).join("");
+      expect(concatenatedDeltas).toBe('{"customer":"Acme"}');
 
       expect(toolCall).toBeDefined();
       expect(toolCall?.toolCallId).toBe(realId);

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -2470,6 +2470,68 @@ describe("SAPAILanguageModel", () => {
       expect(toolCall?.input).toBe('{"customer":"Acme"}');
     });
 
+    it("should replay buffered arguments as tool-input-delta when id arrives after arguments", async () => {
+      const realId = "vertex_tool_buffered_args_test";
+
+      await setStreamChunksForApi(api, [
+        createMockStreamChunk({
+          deltaToolCalls: [
+            {
+              function: { arguments: '{"a":', name: "buffered_fn" },
+              index: 0,
+            },
+          ],
+        }),
+        createMockStreamChunk({
+          deltaToolCalls: [
+            {
+              function: { arguments: '"b"}' },
+              id: realId,
+              index: 0,
+            },
+          ],
+          finishReason: "tool_calls",
+          usage: { completion_tokens: 5, prompt_tokens: 3, total_tokens: 8 },
+        }),
+      ]);
+
+      const model = createModelForApi(api);
+      const prompt = createPrompt("test buffered args");
+
+      const { stream } = await model.doStream({ prompt });
+      const parts = await readAllStreamParts(stream);
+
+      const toolInputStart = parts.find(
+        (p): p is Extract<LanguageModelV3StreamPart, { type: "tool-input-start" }> =>
+          p.type === "tool-input-start",
+      );
+      const toolInputDeltas = parts.filter(
+        (p): p is Extract<LanguageModelV3StreamPart, { type: "tool-input-delta" }> =>
+          p.type === "tool-input-delta",
+      );
+      const toolCall = parts.find(
+        (p): p is Extract<LanguageModelV3StreamPart, { type: "tool-call" }> =>
+          p.type === "tool-call",
+      );
+
+      expect(toolInputStart).toBeDefined();
+      expect(toolInputStart?.id).toBe(realId);
+      expect(toolInputStart?.toolName).toBe("buffered_fn");
+
+      expect(toolInputDeltas).toHaveLength(2);
+      expect(toolInputDeltas[0]?.id).toBe(realId);
+      expect(toolInputDeltas[0]?.delta).toBe('{"a":');
+      expect(toolInputDeltas[1]?.id).toBe(realId);
+      expect(toolInputDeltas[1]?.delta).toBe('"b"}');
+
+      const concatenatedDeltas = toolInputDeltas.map((d) => d.delta).join("");
+      expect(concatenatedDeltas).toBe('{"a":"b"}');
+
+      expect(toolCall).toBeDefined();
+      expect(toolCall?.toolCallId).toBe(realId);
+      expect(toolCall?.input).toBe('{"a":"b"}');
+    });
+
     it("should handle Unicode and multi-byte characters in large streams without corruption", async () => {
       const unicodeContent =
         "Hello 世界! 🌍🌎🌏 Привет мир! مرحبا بالعالم " +

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -985,6 +985,13 @@ export function createStreamTransformer(
                 toolName: tc.toolName,
                 type: "tool-input-start",
               });
+              if (tc.arguments.length > 0) {
+                controller.enqueue({
+                  delta: tc.arguments,
+                  id: tc.id,
+                  type: "tool-input-delta",
+                });
+              }
             }
 
             const argumentsDelta = toolCallChunk.function?.arguments;

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -789,6 +789,31 @@ export function createStreamTransformer(
   const streamState = createInitialStreamState();
   const toolCallsInProgress = new Map<number, ToolCallInProgress>();
 
+  /**
+   * Emits tool-input-start and replays any buffered arguments as a delta.
+   * @param tc - The in-progress tool call state.
+   * @param controller - The transform stream controller to enqueue events into.
+   */
+  function emitToolInputStart(
+    tc: ToolCallInProgress,
+    controller: TransformStreamDefaultController<LanguageModelV3StreamPart>,
+  ): void {
+    if (tc.didEmitInputStart || tc.id == null) return;
+    tc.didEmitInputStart = true;
+    controller.enqueue({
+      id: tc.id,
+      toolName: tc.toolName ?? "",
+      type: "tool-input-start",
+    });
+    if (tc.arguments.length > 0) {
+      controller.enqueue({
+        delta: tc.arguments,
+        id: tc.id,
+        type: "tool-input-delta",
+      });
+    }
+  }
+
   return convertAsyncIteratorToReadableStream(
     safeIterate(sdkStream)[Symbol.asyncIterator](),
   ).pipeThrough(
@@ -803,22 +828,7 @@ export function createStreamTransformer(
           }
 
           tc.id ??= idGenerator.generateToolCallId();
-
-          if (!tc.didEmitInputStart) {
-            tc.didEmitInputStart = true;
-            controller.enqueue({
-              id: tc.id,
-              toolName: tc.toolName ?? "",
-              type: "tool-input-start",
-            });
-            if (tc.arguments.length > 0) {
-              controller.enqueue({
-                delta: tc.arguments,
-                id: tc.id,
-                type: "tool-input-delta",
-              });
-            }
-          }
+          emitToolInputStart(tc, controller);
 
           didEmitAnyToolCalls = true;
           tc.didEmitCall = true;
@@ -968,7 +978,10 @@ export function createStreamTransformer(
                 arguments: "",
                 didEmitCall: false,
                 didEmitInputStart: false,
-                id: toolCallChunk.id ?? undefined,
+                id:
+                  typeof toolCallChunk.id === "string" && toolCallChunk.id.length > 0
+                    ? toolCallChunk.id
+                    : undefined,
                 toolName: toolCallChunk.function?.name,
               });
             }
@@ -976,7 +989,11 @@ export function createStreamTransformer(
             const tc = toolCallsInProgress.get(index);
             if (!tc) continue;
 
-            if (toolCallChunk.id != null && tc.id === undefined) {
+            if (
+              typeof toolCallChunk.id === "string" &&
+              toolCallChunk.id.length > 0 &&
+              tc.id === undefined
+            ) {
               tc.id = toolCallChunk.id;
             }
 
@@ -986,19 +1003,7 @@ export function createStreamTransformer(
             }
 
             if (!tc.didEmitInputStart && tc.toolName != null && tc.id != null) {
-              tc.didEmitInputStart = true;
-              controller.enqueue({
-                id: tc.id,
-                toolName: tc.toolName,
-                type: "tool-input-start",
-              });
-              if (tc.arguments.length > 0) {
-                controller.enqueue({
-                  delta: tc.arguments,
-                  id: tc.id,
-                  type: "tool-input-delta",
-                });
-              }
+              emitToolInputStart(tc, controller);
             }
 
             const argumentsDelta = toolCallChunk.function?.arguments;
@@ -1028,22 +1033,7 @@ export function createStreamTransformer(
               }
 
               tc.id ??= idGenerator.generateToolCallId();
-
-              if (!tc.didEmitInputStart) {
-                tc.didEmitInputStart = true;
-                controller.enqueue({
-                  id: tc.id,
-                  toolName: tc.toolName ?? "",
-                  type: "tool-input-start",
-                });
-                if (tc.arguments.length > 0) {
-                  controller.enqueue({
-                    delta: tc.arguments,
-                    id: tc.id,
-                    type: "tool-input-delta",
-                  });
-                }
-              }
+              emitToolInputStart(tc, controller);
 
               tc.didEmitCall = true;
               controller.enqueue({ id: tc.id, type: "tool-input-end" });

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -811,6 +811,13 @@ export function createStreamTransformer(
               toolName: tc.toolName ?? "",
               type: "tool-input-start",
             });
+            if (tc.arguments.length > 0) {
+              controller.enqueue({
+                delta: tc.arguments,
+                id: tc.id,
+                type: "tool-input-delta",
+              });
+            }
           }
 
           didEmitAnyToolCalls = true;
@@ -1029,6 +1036,13 @@ export function createStreamTransformer(
                   toolName: tc.toolName ?? "",
                   type: "tool-input-start",
                 });
+                if (tc.arguments.length > 0) {
+                  controller.enqueue({
+                    delta: tc.arguments,
+                    id: tc.id,
+                    type: "tool-input-delta",
+                  });
+                }
               }
 
               tc.didEmitCall = true;

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -332,7 +332,7 @@ export interface ToolCallInProgress {
   arguments: string;
   didEmitCall: boolean;
   didEmitInputStart: boolean;
-  id: string;
+  id: string | undefined;
   toolName?: string;
 }
 
@@ -351,6 +351,13 @@ export class StreamIdGenerator {
    * @returns A UUID string for identifying a text block.
    */
   generateTextBlockId(): string {
+    return crypto.randomUUID();
+  }
+
+  /**
+   * @returns A UUID string for identifying a tool call when the API does not provide one.
+   */
+  generateToolCallId(): string {
     return crypto.randomUUID();
   }
 }
@@ -795,6 +802,8 @@ export function createStreamTransformer(
             continue;
           }
 
+          tc.id ??= idGenerator.generateToolCallId();
+
           if (!tc.didEmitInputStart) {
             tc.didEmitInputStart = true;
             controller.enqueue({
@@ -952,7 +961,7 @@ export function createStreamTransformer(
                 arguments: "",
                 didEmitCall: false,
                 didEmitInputStart: false,
-                id: toolCallChunk.id ?? `tool_${String(index)}`,
+                id: toolCallChunk.id ?? undefined,
                 toolName: toolCallChunk.function?.name,
               });
             }
@@ -960,7 +969,7 @@ export function createStreamTransformer(
             const tc = toolCallsInProgress.get(index);
             if (!tc) continue;
 
-            if (toolCallChunk.id) {
+            if (toolCallChunk.id != null && tc.id === undefined) {
               tc.id = toolCallChunk.id;
             }
 
@@ -969,7 +978,7 @@ export function createStreamTransformer(
               tc.toolName = nextToolName;
             }
 
-            if (!tc.didEmitInputStart && tc.toolName) {
+            if (!tc.didEmitInputStart && tc.toolName != null && tc.id != null) {
               tc.didEmitInputStart = true;
               controller.enqueue({
                 id: tc.id,
@@ -982,7 +991,7 @@ export function createStreamTransformer(
             if (typeof argumentsDelta === "string" && argumentsDelta.length > 0) {
               tc.arguments += argumentsDelta;
 
-              if (tc.didEmitInputStart) {
+              if (tc.didEmitInputStart && tc.id != null) {
                 controller.enqueue({
                   delta: argumentsDelta,
                   id: tc.id,
@@ -1003,6 +1012,9 @@ export function createStreamTransformer(
               if (tc.didEmitCall) {
                 continue;
               }
+
+              tc.id ??= idGenerator.generateToolCallId();
+
               if (!tc.didEmitInputStart) {
                 tc.didEmitInputStart = true;
                 controller.enqueue({


### PR DESCRIPTION
## Description

Fix tool-input-start/tool-input-delta ID mismatch when streaming tool calls on Gemini-on-Vertex.

When streaming tool calls from Gemini-on-Vertex via SAP Orchestration, the function `name` and tool call `id` arrive in separate chunks. Previously, `tool-input-start` was emitted with a placeholder ID (`tool_0`) as soon as `toolName` was known, then subsequent `tool-input-delta` events carried the real `vertex_tool_*` ID. This violated the Vercel AI SDK v3 stream contract and caused `processUIMessageStream` to throw `AI_UIMessageStreamError`.

### Root Cause

In `createStreamTransformer()` (strategy-utils.ts), the `tool-input-start` emission guard only checked for `toolName` presence, not for `id` availability. The ID was also mutable — overwritten when the real ID arrived on a later chunk.

### Fix

Aligned with the Vercel AI SDK canonical `StreamingToolCallTracker` pattern:

1. **`ToolCallInProgress.id` is now `string | undefined`** — no placeholder IDs
2. **`tool-input-start` gates on both `toolName` AND `id`** — deferred until both are known (non-empty strings)
3. **ID is immutable once set** — first real non-empty value wins, never overwritten
4. **Buffered arguments replay** — when `tool-input-start` is deferred, any arguments accumulated before the ID arrives are replayed as `tool-input-delta` immediately after start emission
5. **`flush()` / `finishReason` paths use `generateToolCallId()` (UUID)** — fallback matching `@ai-sdk/google` provider pattern
6. **Empty string guard** — `id: ""` is treated as absent (consistent with existing `toolName` guard)
7. **`emitToolInputStart` helper** — extracts the repeated start + buffered replay pattern into a single function, preventing drift between the 3 emission sites (streaming, finishReason, flush)

### Verification

- Tested with synthetic 3-chunk Vertex pattern (name on chunk 1, id on chunk 2, args on chunk 3)
- All 1128 tests pass in Node.js and Edge environments (4 new tests + 1 updated)
- No behavioral change for OpenAI-style streams where `id` arrives on the first chunk
- Zero lint errors, zero warnings

## Type of Change

- [x] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Dependency update

## Checklist

- [x] I have run `npm run type-check && npm run test && npm run prettier-check && npm run lint`
- [x] I have run `npm run build && npm run check-build && npm run build:v2 && npm run check-build:v2`
- [ ] I have updated documentation (if applicable)
- [x] I have added tests for new functionality (if applicable)
- [x] My changes follow the existing code style

## Related Issues

Fixes #93

## Additional Notes

### Test Coverage

| Test | Scenario |
|------|----------|
| Vertex pattern | `id` arrives on chunk 2, `name` on chunk 1 |
| Buffered args replay | Arguments arrive before `id` — replayed after start |
| UUID fallback | API never provides `id` — UUID generated, consistent across events |
| Existing test updated | `name` arrives late (was "flush unflushed") — now verifies full start+delta+call sequence |

### Reference Implementations Consulted

- **`@ai-sdk/provider-utils` `StreamingToolCallTracker`** — requires `id` on first chunk (throws if null), stores it immutably. Our fix adopts the same "immutable once set" semantic but relaxes "throw" to "defer".
- **`@ai-sdk/google`** — uses `part.toolCall.id ?? generateId()` for fallback UUID generation.
- **`@ai-sdk/anthropic`** — ID always present in `content_block_start` (atomic event), no placeholder needed.

### Files Changed

- `src/strategy-utils.ts` — Core fix + `emitToolInputStart` helper extraction
- `src/sap-ai-language-model.test.ts` — 4 new regression tests + 1 updated existing test