### PR TITLE
feat: integrate @sap-ai-sdk 2.10 → 2.11 surface (closes #73, closes #71)

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -863,6 +863,15 @@ Configuration options for embedding models.
 | `modelParams`          | `EmbeddingModelParams` | -                 | Model-specific parameters                                 |
 | `masking`              | `MaskingModule`        | -                 | Data masking configuration (DPI) - Orchestration API only |
 
+**Embedding response metadata (`doEmbed` result):**
+
+| Field                                  | Type                     | Description                                                                                             |
+| -------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------- |
+| `response.headers`                     | `Record<string, string>` | Lower-cased response headers from the SDK call                                                          |
+| `providerMetadata['sap-ai'].model`     | `string`                 | Embedding model id                                                                                      |
+| `providerMetadata['sap-ai'].requestId` | `string \| undefined`    | SAP-pipeline correlation id (`getRequestId()` preferred, lower-cased `x-request-id` header as fallback) |
+| `providerMetadata['sap-ai'].version`   | `string`                 | Provider package version                                                                                |
+
 **EmbeddingType Values:**
 
 - `'document'` - For embedding documents (storage/indexing)
@@ -1505,6 +1514,66 @@ const result = await generateText({
     },
   },
 });
+```
+
+---
+
+### Per-message-part Provider Options (Anthropic prompt caching)
+
+Anthropic prompt caching is opted into per message part (or per tool definition)
+through `providerOptions['sap-ai'].cacheControl`. The orchestration API forwards
+the directive as `cache_control` on the SAP envelope; Foundation Models drops it
+silently because the `cache_control` field is orchestration-only.
+
+**Input shape:**
+
+```typescript
+type CacheControl = {
+  type: "ephemeral";
+  ttl?: "5m" | "1h"; // SAP-supported TTL buckets; other values are dropped with a warning
+};
+```
+
+**Supported parts (orchestration API):**
+
+| Surface             | Carrier                                                       |
+| ------------------- | ------------------------------------------------------------- |
+| user text part      | `prompt[i].content[j].providerOptions['sap-ai'].cacheControl` |
+| user file part      | `prompt[i].content[j].providerOptions['sap-ai'].cacheControl` |
+| system message      | `prompt[i].providerOptions['sap-ai'].cacheControl`            |
+| assistant text part | `prompt[i].content[j].providerOptions['sap-ai'].cacheControl` |
+| tool-result message | `prompt[i].content[j].providerOptions['sap-ai'].cacheControl` |
+| tool definition     | `tool.providerOptions['sap-ai'].cacheControl`                 |
+
+Setting `cacheControl` on an assistant `tool-call` part raises a single
+`unsupported` warning (the SAP envelope does not expose `cache_control` on tool
+calls). Invalid blocks are silently dropped and surface a `type: "other"` warning
+that names the offending path.
+
+**Example:**
+
+```typescript
+const result = await generateText({
+  model: provider("anthropic--claude-4.5-sonnet"),
+  prompt: [
+    {
+      role: "user",
+      content: [
+        {
+          type: "text",
+          text: "Long shared context...",
+          providerOptions: {
+            "sap-ai": { cacheControl: { type: "ephemeral", ttl: "5m" } },
+          },
+        },
+        { type: "text", text: "Question that varies per call" },
+      ],
+    },
+  ],
+});
+
+const cacheUsage = result.providerMetadata?.["sap-ai"]?.cacheUsage;
+// { ephemeral_5m_input_tokens: 1234, ephemeral_1h_input_tokens: 0 }
 ```
 
 ---
@@ -2182,18 +2251,12 @@ Implementation of Vercel AI SDK's `LanguageModelV3` interface.
 
 **Properties:**
 
-| Property                      | Type                       | Description                                         |
-| ----------------------------- | -------------------------- | --------------------------------------------------- |
-| `specificationVersion`        | `'v3'`                     | API specification version (readonly)                |
-| `modelId`                     | `SAPAIModelId`             | Current model identifier (readonly)                 |
-| `provider`                    | `string`                   | Provider identifier (getter, e.g., `'sap-ai.chat'`) |
-| `supportedUrls`               | `Record<string, RegExp[]>` | URL patterns for supported media (getter)           |
-| `supportsImageUrls`           | `true`                     | Image URL support flag (readonly)                   |
-| `supportsMultipleCompletions` | `true`                     | Multiple completions support (readonly)             |
-| `supportsParallelToolCalls`   | `true`                     | Parallel tool calls support (readonly)              |
-| `supportsStreaming`           | `true`                     | Streaming support (readonly)                        |
-| `supportsStructuredOutputs`   | `true`                     | Structured output support (readonly)                |
-| `supportsToolCalls`           | `true`                     | Tool calling support (readonly)                     |
+| Property               | Type                       | Description                                         |
+| ---------------------- | -------------------------- | --------------------------------------------------- |
+| `specificationVersion` | `'v3'`                     | API specification version (readonly)                |
+| `modelId`              | `SAPAIModelId`             | Current model identifier (readonly)                 |
+| `provider`             | `string`                   | Provider identifier (getter, e.g., `'sap-ai.chat'`) |
+| `supportedUrls`        | `Record<string, RegExp[]>` | URL patterns for supported media (getter)           |
 
 **Methods:**
 
@@ -2317,8 +2380,9 @@ for await (const part of stream) {
 ```
 
 > **Note:** Streaming response IDs (`response-metadata.id`) are extracted from
-> the server's completion response when available. The `x-request-id` header is
-> also exposed in `providerMetadata` for request correlation — see
+> the server's completion response when available. `providerMetadata.requestId`
+> resolves to the SAP-pipeline correlation id (`getRequestId()` preferred, lower-cased
+> `x-request-id` header as fallback) — see
 > [Provider Metadata](#provider-metadata-in-responses).
 
 ---
@@ -2330,23 +2394,26 @@ SAP-specific fields under the provider name key (default: `"sap-ai"`).
 
 **`doGenerate` — `providerMetadata[providerName]`:**
 
-| Field                  | Type                  | Description                                  |
-| ---------------------- | --------------------- | -------------------------------------------- |
-| `finishReason`         | `string \| undefined` | Raw finish reason from the SDK               |
-| `finishReasonMapped`   | `object`              | Mapped finish reason (`{ raw, unified }`)    |
-| `intermediateFailures` | `array \| undefined`  | Errors from fallback retries (orchestration) |
-| `requestId`            | `string \| undefined` | Server's `x-request-id` header (if present)  |
-| `version`              | `string`              | Provider package version                     |
+| Field                  | Type                  | Description                                                                                                |
+| ---------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `cacheUsage`           | `object \| undefined` | Anthropic prompt-cache breakdown (`ephemeral_5m_input_tokens`, `ephemeral_1h_input_tokens`) when populated |
+| `finishReason`         | `string \| undefined` | Raw finish reason from the SDK                                                                             |
+| `finishReasonMapped`   | `object`              | Mapped finish reason (`{ raw, unified }`)                                                                  |
+| `intermediateFailures` | `array \| undefined`  | Errors from fallback retries (orchestration)                                                               |
+| `requestId`            | `string \| undefined` | SAP-pipeline correlation id (`getRequestId()` preferred, lower-cased `x-request-id` header as fallback)    |
+| `version`              | `string`              | Provider package version                                                                                   |
 
 **`doStream` — `finish` event `providerMetadata[providerName]`:**
 
-| Field                  | Type                  | Description                                   |
-| ---------------------- | --------------------- | --------------------------------------------- |
-| `finishReason`         | `string \| undefined` | Raw finish reason from the SDK                |
-| `intermediateFailures` | `array \| undefined`  | Errors from fallback retries (orchestration)  |
-| `requestId`            | `string \| undefined` | Server's `x-request-id` header (if present)   |
-| `responseId`           | `string`              | Server completion ID or client-generated UUID |
-| `version`              | `string`              | Provider package version                      |
+| Field                  | Type                  | Description                                                                                                |
+| ---------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------- |
+| `cacheUsage`           | `object \| undefined` | Anthropic prompt-cache breakdown (`ephemeral_5m_input_tokens`, `ephemeral_1h_input_tokens`) when populated |
+| `finishReason`         | `string \| undefined` | Raw finish reason from the SDK                                                                             |
+| `finishReasonMapped`   | `object`              | Mapped finish reason (`{ raw, unified }`)                                                                  |
+| `intermediateFailures` | `array \| undefined`  | Errors from fallback retries (orchestration)                                                               |
+| `requestId`            | `string \| undefined` | SAP-pipeline correlation id (`getRequestId()` preferred, lower-cased `x-request-id` header as fallback)    |
+| `responseId`           | `string`              | Server completion ID or client-generated UUID                                                              |
+| `version`              | `string`              | Provider package version                                                                                   |
 
 **Example (non-streaming):**
 
@@ -2360,7 +2427,7 @@ const result = await generateText({
 });
 
 const metadata = result.providerMetadata?.[SAP_AI_PROVIDER_NAME];
-console.log(metadata?.requestId); // "abc-123-def" (server x-request-id)
+console.log(metadata?.requestId); // "abc-123-def" (SAP pipeline correlation id)
 console.log(metadata?.version); // "4.x.x"
 ```
 
@@ -2378,7 +2445,7 @@ const result = streamText({
 for await (const part of result.fullStream) {
   if (part.type === "finish") {
     const metadata = part.providerMetadata?.[SAP_AI_PROVIDER_NAME];
-    console.log(metadata?.requestId); // Server x-request-id
+    console.log(metadata?.requestId); // SAP pipeline correlation id
     console.log(metadata?.responseId); // Server completion ID
   }
 }

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -866,12 +866,12 @@ Configuration options for embedding models.
 
 **Embedding response metadata (`doEmbed` result):**
 
-| Field                                  | Type                     | Description                                                                                             |
-| -------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------------------- |
-| `response.headers`                     | `Record<string, string>` | Lower-cased response headers from the SDK call                                                          |
-| `providerMetadata['sap-ai'].model`     | `string`                 | Embedding model id                                                                                      |
-| `providerMetadata['sap-ai'].requestId` | `string \| undefined`    | SAP-pipeline correlation id (`getRequestId()` preferred, lower-cased `x-request-id` header as fallback) |
-| `providerMetadata['sap-ai'].version`   | `string`                 | Provider package version                                                                                |
+| Field                                  | Type                     | Description                                                                                 |
+| -------------------------------------- | ------------------------ | ------------------------------------------------------------------------------------------- |
+| `response.headers`                     | `Record<string, string>` | Response headers (keys lower-cased)                                                         |
+| `providerMetadata['sap-ai'].model`     | `string`                 | Embedding model id                                                                          |
+| `providerMetadata['sap-ai'].requestId` | `string \| undefined`    | SAP request correlation id (from the SDK response; falls back to the `x-request-id` header) |
+| `providerMetadata['sap-ai'].version`   | `string`                 | Provider package version                                                                    |
 
 **EmbeddingType Values:**
 
@@ -1521,17 +1521,16 @@ const result = await generateText({
 
 ### Per-message-part Provider Options (Anthropic prompt caching)
 
-Anthropic prompt caching is opted into per message part (or per tool definition)
-through `providerOptions['sap-ai'].cacheControl`. The orchestration API forwards
-the directive as `cache_control` on the SAP envelope; Foundation Models drops it
-silently because the `cache_control` field is orchestration-only.
+Per-part directive (`providerOptions['sap-ai'].cacheControl`) requesting
+Anthropic ephemeral prompt caching. Honored only by the orchestration API
+(forwarded as `cache_control`); Foundation Models ignores it.
 
 **Input shape:**
 
 ```typescript
 type CacheControl = {
   type: "ephemeral";
-  ttl?: "5m" | "1h"; // SAP-supported TTL buckets; other values are dropped with a warning
+  ttl?: "5m" | "1h"; // invalid values drop the whole `cacheControl` block (warning emitted)
 };
 ```
 
@@ -1546,10 +1545,9 @@ type CacheControl = {
 | tool-result message | `prompt[i].content[j].providerOptions['sap-ai'].cacheControl` |
 | tool definition     | `tool.providerOptions['sap-ai'].cacheControl`                 |
 
-Setting `cacheControl` on an assistant `tool-call` part raises a single
-`unsupported` warning (the SAP envelope does not expose `cache_control` on tool
-calls). Invalid blocks are silently dropped and surface a `type: "other"` warning
-that names the offending path.
+`cacheControl` on an assistant `tool-call` part is unsupported and emits a
+single `unsupported` warning (deduplicated by feature key). Invalid blocks are
+dropped and surface a `type: "other"` warning naming the offending path.
 
 **Example:**
 
@@ -1574,7 +1572,7 @@ const result = await generateText({
 });
 
 const cacheUsage = result.providerMetadata?.["sap-ai"]?.cacheUsage;
-// { ephemeral_5m_input_tokens: 1234, ephemeral_1h_input_tokens: 0 }
+// e.g. { ephemeral_5m_input_tokens: 1234 } — keys present only when non-zero
 ```
 
 ---
@@ -2382,8 +2380,7 @@ for await (const part of stream) {
 
 > **Note:** Streaming response IDs (`response-metadata.id`) are extracted from
 > the server's completion response when available. `providerMetadata.requestId`
-> resolves to the SAP-pipeline correlation id (`getRequestId()` preferred, lower-cased
-> `x-request-id` header as fallback) — see
+> exposes the SAP request correlation id — see
 > [Provider Metadata](#provider-metadata-in-responses).
 
 ---
@@ -2401,7 +2398,7 @@ SAP-specific fields under the provider name key (default: `"sap-ai"`).
 | `finishReason`         | `string \| undefined` | Raw finish reason from the SDK                                                                             |
 | `finishReasonMapped`   | `object`              | Mapped finish reason (`{ raw, unified }`)                                                                  |
 | `intermediateFailures` | `array \| undefined`  | Errors from fallback retries (orchestration)                                                               |
-| `requestId`            | `string \| undefined` | SAP-pipeline correlation id (`getRequestId()` preferred, lower-cased `x-request-id` header as fallback)    |
+| `requestId`            | `string \| undefined` | SAP request correlation id (from the SDK response; falls back to the `x-request-id` header)                |
 | `version`              | `string`              | Provider package version                                                                                   |
 
 **`doStream` — `finish` event `providerMetadata[providerName]`:**
@@ -2412,7 +2409,7 @@ SAP-specific fields under the provider name key (default: `"sap-ai"`).
 | `finishReason`         | `string \| undefined` | Raw finish reason from the SDK                                                                             |
 | `finishReasonMapped`   | `object`              | Mapped finish reason (`{ raw, unified }`)                                                                  |
 | `intermediateFailures` | `array \| undefined`  | Errors from fallback retries (orchestration)                                                               |
-| `requestId`            | `string \| undefined` | SAP-pipeline correlation id (`getRequestId()` preferred, lower-cased `x-request-id` header as fallback)    |
+| `requestId`            | `string \| undefined` | SAP request correlation id (from the SDK response; falls back to the `x-request-id` header)                |
 | `responseId`           | `string`              | Server completion ID or client-generated UUID                                                              |
 | `version`              | `string`              | Provider package version                                                                                   |
 

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1572,7 +1572,8 @@ const result = await generateText({
 });
 
 const cacheUsage = result.providerMetadata?.["sap-ai"]?.cacheUsage;
-// e.g. { ephemeral_5m_input_tokens: 1234 } — keys present only when non-zero
+// e.g. { ephemeral_5m_input_tokens: 1234, ephemeral_1h_input_tokens: 0 }
+// `cacheUsage` is omitted only when all buckets are zero; individual zero keys are preserved.
 ```
 
 ---
@@ -2395,8 +2396,8 @@ SAP-specific fields under the provider name key (default: `"sap-ai"`).
 | Field                  | Type                  | Description                                                                                                |
 | ---------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------- |
 | `cacheUsage`           | `object \| undefined` | Anthropic prompt-cache breakdown (`ephemeral_5m_input_tokens`, `ephemeral_1h_input_tokens`) when populated |
-| `finishReason`         | `string \| undefined` | Raw finish reason from the SDK                                                                             |
-| `finishReasonMapped`   | `object`              | Mapped finish reason (`{ raw, unified }`)                                                                  |
+| `finishReason`         | `string`              | Raw finish reason from the SDK; defaults to `"unknown"` when the SDK omits it                              |
+| `finishReasonMapped`   | `object`              | Mapped finish reason (`{ raw, unified }`); `raw` preserves the unmodified SDK value (or `undefined`)       |
 | `intermediateFailures` | `array \| undefined`  | Errors from fallback retries (orchestration)                                                               |
 | `requestId`            | `string \| undefined` | SAP request correlation id (from the SDK response; falls back to the `x-request-id` header)                |
 | `version`              | `string`              | Provider package version                                                                                   |
@@ -2406,8 +2407,8 @@ SAP-specific fields under the provider name key (default: `"sap-ai"`).
 | Field                  | Type                  | Description                                                                                                |
 | ---------------------- | --------------------- | ---------------------------------------------------------------------------------------------------------- |
 | `cacheUsage`           | `object \| undefined` | Anthropic prompt-cache breakdown (`ephemeral_5m_input_tokens`, `ephemeral_1h_input_tokens`) when populated |
-| `finishReason`         | `string \| undefined` | Raw finish reason from the SDK                                                                             |
-| `finishReasonMapped`   | `object`              | Mapped finish reason (`{ raw, unified }`)                                                                  |
+| `finishReason`         | `string`              | Raw finish reason from the SDK; defaults to `"unknown"` when the SDK omits it                              |
+| `finishReasonMapped`   | `object`              | Mapped finish reason (`{ raw, unified }`); `raw` preserves the unmodified SDK value (or `undefined`)       |
 | `intermediateFailures` | `array \| undefined`  | Errors from fallback retries (orchestration)                                                               |
 | `requestId`            | `string \| undefined` | SAP request correlation id (from the SDK response; falls back to the `x-request-id` header)                |
 | `responseId`           | `string`              | Server completion ID or client-generated UUID                                                              |

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -67,6 +67,7 @@ consistently:
   - [`DpiConfig`](#dpiconfig)
 - [Provider Options](#provider-options)
   - [`SAP_AI_PROVIDER_NAME`](#sap-ai-provider-name-constant)
+  - [Per-message-part Provider Options (Anthropic prompt caching)](#per-message-part-provider-options-anthropic-prompt-caching)
   - [`sapAILanguageModelProviderOptions`](#sapailanguagemodelprovideroptions)
   - [`sapAIEmbeddingProviderOptions`](#sapaiembeddingprovideroptions)
   - [`SAPAILanguageModelProviderOptions` (Type)](#sapailanguagemodelprovideroptions-type)

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -793,7 +793,7 @@ messages including request IDs and error locations for debugging.
 | `buildDocumentGroundingConfig()`        | Document grounding      | `buildDocumentGroundingConfig({ filters: [...], placeholders: {...} })`           |
 | `buildTranslationConfig()`              | Translation module      | `buildTranslationConfig("input", { sourceLanguage: "de", targetLanguage: "en" })` |
 | `SAPAISettings.responseFormat`          | Structured outputs      | `{ type: "json_schema", json_schema: {...} }`                                     |
-| `SAPAISettings.masking`                 | Masking configuration   | `{ masking_providers: [...] }`                                                    |
+| `SAPAISettings.masking`                 | Masking configuration   | `{ providers: [...] }`                                                            |
 | `SAPAISettings.filtering`               | Content filtering       | `{ input: { filters: [...] } }`                                                   |
 | `SAPAIProviderSettings.defaultSettings` | Provider defaults       | `{ defaultSettings: { modelParams: {...} } }`                                     |
 

--- a/examples/example-data-masking.ts
+++ b/examples/example-data-masking.ts
@@ -56,7 +56,7 @@ async function dataMaskingExample() {
     const provider = createSAPAIProvider({
       defaultSettings: {
         masking: {
-          masking_providers: [dpiMaskingConfig],
+          providers: [dpiMaskingConfig],
         },
       },
     });

--- a/src/base-embedding-model-strategy.ts
+++ b/src/base-embedding-model-strategy.ts
@@ -61,11 +61,15 @@ export abstract class BaseEmbeddingModelStrategy<
 
       const embeddings = this.extractEmbeddings(response);
       const totalTokens = this.extractTokenCount(response);
+      const responseId = this.extractRequestId(response);
+      const responseHeaders = this.extractResponseHeaders(response);
 
       return buildEmbeddingResult({
         embeddings,
         modelId: config.modelId,
         providerName,
+        responseHeaders,
+        responseId,
         totalTokens,
         version: VERSION,
       });
@@ -118,6 +122,33 @@ export abstract class BaseEmbeddingModelStrategy<
    * @internal
    */
   protected abstract extractEmbeddings(response: TResponse): EmbeddingModelV3Embedding[];
+
+  /**
+   * Extracts the server-provided request id from the SDK response.
+   *
+   * Default returns `undefined`. Subclasses override when the SDK exposes
+   * `getRequestId()`.
+   * @param _response - SDK response.
+   * @returns Server-provided request id, or undefined.
+   * @internal
+   */
+  protected extractRequestId(_response: TResponse): string | undefined {
+    return undefined;
+  }
+
+  /**
+   * Extracts response headers from the SDK response, normalised to lower-case keys.
+   *
+   * Default returns `undefined`. Subclasses override to lift the underlying
+   * `HttpResponse.headers` (the SDKs disagree on the field name — `rawResponse`
+   * for foundation-models, `response` for orchestration).
+   * @param _response - SDK response.
+   * @returns Normalised header bag, or undefined.
+   * @internal
+   */
+  protected extractResponseHeaders(_response: TResponse): Record<string, string> | undefined {
+    return undefined;
+  }
 
   /**
    * Extracts total token count from the SDK response.

--- a/src/base-embedding-model-strategy.ts
+++ b/src/base-embedding-model-strategy.ts
@@ -131,10 +131,7 @@ export abstract class BaseEmbeddingModelStrategy<
   /**
    * Extracts response metadata (request id and HTTP headers) from the SDK response.
    *
-   * Default returns both fields as `undefined`. Subclasses override to lift the
-   * underlying `HttpResponse` via `extractResponseMetadata` from `strategy-utils`,
-   * passing the SDK-specific field name (`rawResponse` for foundation-models,
-   * `response` for orchestration).
+   * Default returns both fields as `undefined`; subclasses override to extract from the SDK response.
    * @param _response - SDK response.
    * @returns Combined `{ headers, requestId }` metadata.
    * @internal

--- a/src/base-embedding-model-strategy.ts
+++ b/src/base-embedding-model-strategy.ts
@@ -3,6 +3,7 @@ import type {
   EmbeddingModelV3CallOptions,
   EmbeddingModelV3Embedding,
   EmbeddingModelV3Result,
+  SharedV3Warning,
 } from "@ai-sdk/provider";
 
 import { TooManyEmbeddingValuesForCallError } from "@ai-sdk/provider";
@@ -56,6 +57,9 @@ export abstract class BaseEmbeddingModelStrategy<
 
       const embeddingType = embeddingOptions?.type ?? settings.type ?? "text";
 
+      const warnings: SharedV3Warning[] = [];
+      this.resolveWarnings(settings, warnings);
+
       const client = this.createClient(config, settings, embeddingOptions);
 
       const response = await this.executeCall(client, values, embeddingType, abortSignal);
@@ -72,6 +76,7 @@ export abstract class BaseEmbeddingModelStrategy<
         responseHeaders,
         totalTokens,
         version: VERSION,
+        warnings,
       });
     } catch (error) {
       if (error instanceof TooManyEmbeddingValuesForCallError) {
@@ -161,5 +166,17 @@ export abstract class BaseEmbeddingModelStrategy<
       (settings.modelParams as Record<string, unknown> | undefined) ?? {},
       embeddingOptions?.modelParams ?? {},
     );
+  }
+
+  /**
+   * Pushes API-specific deprecation or migration warnings into the shared
+   * sink. Default no-op; subclasses override to surface settings-level
+   * warnings (e.g. orchestration's masking_providers deprecation).
+   * @param _settings - Embedding model settings.
+   * @param _warnings - Shared warnings sink for the current call.
+   * @internal
+   */
+  protected resolveWarnings(_settings: SAPAIEmbeddingSettings, _warnings: SharedV3Warning[]): void {
+    return;
   }
 }

--- a/src/base-embedding-model-strategy.ts
+++ b/src/base-embedding-model-strategy.ts
@@ -17,6 +17,7 @@ import {
   type EmbeddingProviderOptions,
   type EmbeddingType,
   prepareEmbeddingCall,
+  type ResponseMetadata,
 } from "./strategy-utils.js";
 import { VERSION } from "./version.js";
 
@@ -61,8 +62,8 @@ export abstract class BaseEmbeddingModelStrategy<
 
       const embeddings = this.extractEmbeddings(response);
       const totalTokens = this.extractTokenCount(response);
-      const responseId = this.extractRequestId(response);
-      const responseHeaders = this.extractResponseHeaders(response);
+      const { headers: responseHeaders, requestId: responseId } =
+        this.extractResponseMetadata(response);
 
       return buildEmbeddingResult({
         embeddings,
@@ -124,30 +125,18 @@ export abstract class BaseEmbeddingModelStrategy<
   protected abstract extractEmbeddings(response: TResponse): EmbeddingModelV3Embedding[];
 
   /**
-   * Extracts the server-provided request id from the SDK response.
+   * Extracts response metadata (request id and HTTP headers) from the SDK response.
    *
-   * Default returns `undefined`. Subclasses override when the SDK exposes
-   * `getRequestId()`.
+   * Default returns both fields as `undefined`. Subclasses override to lift the
+   * underlying `HttpResponse` via `extractResponseMetadata` from `strategy-utils`,
+   * passing the SDK-specific field name (`rawResponse` for foundation-models,
+   * `response` for orchestration).
    * @param _response - SDK response.
-   * @returns Server-provided request id, or undefined.
+   * @returns Combined `{ headers, requestId }` metadata.
    * @internal
    */
-  protected extractRequestId(_response: TResponse): string | undefined {
-    return undefined;
-  }
-
-  /**
-   * Extracts response headers from the SDK response, normalised to lower-case keys.
-   *
-   * Default returns `undefined`. Subclasses override to lift the underlying
-   * `HttpResponse.headers` (the SDKs disagree on the field name — `rawResponse`
-   * for foundation-models, `response` for orchestration).
-   * @param _response - SDK response.
-   * @returns Normalised header bag, or undefined.
-   * @internal
-   */
-  protected extractResponseHeaders(_response: TResponse): Record<string, string> | undefined {
-    return undefined;
+  protected extractResponseMetadata(_response: TResponse): ResponseMetadata {
+    return { headers: undefined, requestId: undefined };
   }
 
   /**

--- a/src/base-embedding-model-strategy.ts
+++ b/src/base-embedding-model-strategy.ts
@@ -62,15 +62,14 @@ export abstract class BaseEmbeddingModelStrategy<
 
       const embeddings = this.extractEmbeddings(response);
       const totalTokens = this.extractTokenCount(response);
-      const { headers: responseHeaders, requestId: responseId } =
-        this.extractResponseMetadata(response);
+      const { headers: responseHeaders, requestId } = this.extractResponseMetadata(response);
 
       return buildEmbeddingResult({
         embeddings,
         modelId: config.modelId,
         providerName,
+        requestId,
         responseHeaders,
-        responseId,
         totalTokens,
         version: VERSION,
       });

--- a/src/base-language-model-strategy.ts
+++ b/src/base-language-model-strategy.ts
@@ -328,9 +328,7 @@ export abstract class BaseLanguageModelStrategy<
   ): Promise<StreamCallResponse>;
 
   /**
-   * Resolves request id, completion id, and normalised headers from an SDK
-   * response in one place. Used by `executeApiCall` and `executeStreamCall`
-   * overrides so each call site goes through the same extraction pipeline.
+   * Resolves request id, completion id, and normalised headers from an SDK response.
    * @param response - Raw SDK response or stream response.
    * @returns Combined metadata fragment.
    * @internal
@@ -396,9 +394,8 @@ export abstract class BaseLanguageModelStrategy<
   /**
    * Returns a parser for per-message-part `providerOptions['sap-ai']`.
    *
-   * Default returns `undefined`. Strategies that honour part-level directives
-   * (e.g. orchestration `cache_control` for Anthropic) override to return the
-   * `parseSAPPartProviderOptions` parser.
+   * Default returns `undefined`; strategies honouring part-level directives
+   * (e.g. Anthropic `cacheControl` on orchestration) override to return a parser.
    * @returns Parser callback, or undefined to disable per-part plumbing.
    * @internal
    */

--- a/src/base-language-model-strategy.ts
+++ b/src/base-language-model-strategy.ts
@@ -16,6 +16,7 @@ import type { LanguageModelAPIStrategy, LanguageModelStrategyConfig } from "./sa
 import { convertToSAPMessages } from "./convert-to-sap-messages.js";
 import { convertToAISDKError, normalizeHeaders } from "./sap-ai-error.js";
 import { getProviderName, sapAILanguageModelProviderOptions } from "./sap-ai-provider-options.js";
+import { pushDeprecatedMaskingProvidersWarning } from "./sap-ai-validation.js";
 import {
   buildGenerateResult,
   buildModelParams,
@@ -210,6 +211,8 @@ export abstract class BaseLanguageModelStrategy<
     });
 
     const warnings: SharedV3Warning[] = [];
+
+    pushDeprecatedMaskingProvidersWarning(settings, warnings);
 
     const messages = convertToSAPMessages(options.prompt, {
       escapeTemplatePlaceholders: this.getEscapeTemplatePlaceholders(sapOptions, settings),

--- a/src/base-language-model-strategy.ts
+++ b/src/base-language-model-strategy.ts
@@ -215,6 +215,7 @@ export abstract class BaseLanguageModelStrategy<
       escapeTemplatePlaceholders: this.getEscapeTemplatePlaceholders(sapOptions, settings),
       includeReasoning: this.getIncludeReasoning(sapOptions, settings),
       parsePartProviderOptions: this.getPartProviderOptionsParser(),
+      warnings,
     });
 
     const { modelParams, warnings: paramWarnings } = buildModelParams({

--- a/src/base-language-model-strategy.ts
+++ b/src/base-language-model-strategy.ts
@@ -57,6 +57,8 @@ export interface StreamCallResponse {
   readonly getFinishReason: () => null | string | undefined;
   readonly getIntermediateFailures?: () => undefined | unknown[];
   readonly getTokenUsage: () => null | SDKTokenUsage | undefined;
+  /** SAP-pipeline request id resolved by `extractResponseMetadata`. */
+  readonly requestId?: string;
   readonly responseHeaders?: Record<string, string>;
   /** Server-provided completion ID extracted from _data, if available. */
   readonly responseId?: string;
@@ -114,6 +116,7 @@ export abstract class BaseLanguageModelStrategy<
         modelId: config.modelId,
         providerName: commonParts.providerName,
         requestBody: request,
+        requestId: response.requestId,
         response,
         responseHeaders: normalizeHeaders(response.rawResponse.headers),
         version: VERSION,
@@ -158,7 +161,7 @@ export abstract class BaseLanguageModelStrategy<
         modelId: config.modelId,
         options,
         providerName: commonParts.providerName,
-        responseHeaders: streamResponse.responseHeaders,
+        requestId: streamResponse.requestId,
         responseId,
         sdkStream: streamResponse.stream,
         streamResponseGetCitations: streamResponse.getCitations,

--- a/src/base-language-model-strategy.ts
+++ b/src/base-language-model-strategy.ts
@@ -213,6 +213,7 @@ export abstract class BaseLanguageModelStrategy<
     const messages = convertToSAPMessages(options.prompt, {
       escapeTemplatePlaceholders: this.getEscapeTemplatePlaceholders(sapOptions, settings),
       includeReasoning: this.getIncludeReasoning(sapOptions, settings),
+      parsePartProviderOptions: this.getPartProviderOptionsParser(),
     });
 
     const { modelParams, warnings: paramWarnings } = buildModelParams({
@@ -346,6 +347,23 @@ export abstract class BaseLanguageModelStrategy<
    * @internal
    */
   protected abstract getParamMappings(): readonly ParamMapping[];
+
+  /**
+   * Returns a parser for per-message-part `providerOptions['sap-ai']`.
+   *
+   * Default returns `undefined`. Strategies that honour part-level directives
+   * (e.g. orchestration `cache_control` for Anthropic) override to return the
+   * `parseSAPPartProviderOptions` parser.
+   * @returns Parser callback, or undefined to disable per-part plumbing.
+   * @internal
+   */
+  protected getPartProviderOptionsParser():
+    | ((
+        providerOptions: unknown,
+      ) => undefined | { readonly cacheControl?: { ttl?: "1h" | "5m"; type: "ephemeral" } })
+    | undefined {
+    return undefined;
+  }
 
   /**
    * Returns the URL identifier for this API (used in error messages).

--- a/src/base-language-model-strategy.ts
+++ b/src/base-language-model-strategy.ts
@@ -16,7 +16,6 @@ import type { LanguageModelAPIStrategy, LanguageModelStrategyConfig } from "./sa
 import { convertToSAPMessages } from "./convert-to-sap-messages.js";
 import { convertToAISDKError, normalizeHeaders } from "./sap-ai-error.js";
 import { getProviderName, sapAILanguageModelProviderOptions } from "./sap-ai-provider-options.js";
-import { pushDeprecatedMaskingProvidersWarning } from "./sap-ai-validation.js";
 import {
   buildGenerateResult,
   buildModelParams,
@@ -211,8 +210,6 @@ export abstract class BaseLanguageModelStrategy<
     });
 
     const warnings: SharedV3Warning[] = [];
-
-    pushDeprecatedMaskingProvidersWarning(settings, warnings);
 
     const messages = convertToSAPMessages(options.prompt, {
       escapeTemplatePlaceholders: this.getEscapeTemplatePlaceholders(sapOptions, settings),

--- a/src/base-language-model-strategy.ts
+++ b/src/base-language-model-strategy.ts
@@ -216,6 +216,14 @@ export abstract class BaseLanguageModelStrategy<
 
     const warnings: SharedV3Warning[] = [];
 
+    const resolvedState = this.resolveAdditionalState(
+      config,
+      settings,
+      sapOptions,
+      options,
+      warnings,
+    );
+
     const messages = convertToSAPMessages(options.prompt, {
       escapeTemplatePlaceholders: this.getEscapeTemplatePlaceholders(sapOptions, settings),
       includeReasoning: this.getIncludeReasoning(sapOptions, settings),
@@ -237,6 +245,7 @@ export abstract class BaseLanguageModelStrategy<
       messages,
       modelParams,
       providerName,
+      resolvedState,
       sapOptions,
       toolChoice,
       warnings,
@@ -403,4 +412,27 @@ export abstract class BaseLanguageModelStrategy<
    * @internal
    */
   protected abstract getUrl(): string;
+
+  /**
+   * Resolves API-specific extra state shared between doGenerate and doStream
+   * (e.g. orchestration `configRef` / `promptTemplateRef` / `tools`). Override
+   * to add API-specific deprecation checks or pre-resolve auxiliary inputs.
+   * Pushed warnings flow into the shared sink.
+   * @param _config - Strategy configuration.
+   * @param _settings - Model settings.
+   * @param _sapOptions - Parsed provider options, or `undefined`.
+   * @param _options - AI SDK call options.
+   * @param _warnings - Shared warnings sink for the current call.
+   * @returns Strategy-specific resolved state, or `undefined` (default).
+   * @internal
+   */
+  protected resolveAdditionalState(
+    _config: LanguageModelStrategyConfig,
+    _settings: TSettings,
+    _sapOptions: Record<string, unknown> | undefined,
+    _options: LanguageModelV3CallOptions,
+    _warnings: SharedV3Warning[],
+  ): unknown {
+    return undefined;
+  }
 }

--- a/src/base-language-model-strategy.ts
+++ b/src/base-language-model-strategy.ts
@@ -9,6 +9,7 @@ import type { ChatMessage } from "@sap-ai-sdk/orchestration";
 
 import { parseProviderOptions } from "@ai-sdk/provider-utils";
 
+import type { ParsePartProviderOptions } from "./sap-ai-provider-options.js";
 import type { SAPAIModelSettings } from "./sap-ai-settings.js";
 import type { LanguageModelAPIStrategy, LanguageModelStrategyConfig } from "./sap-ai-strategy.js";
 
@@ -357,11 +358,7 @@ export abstract class BaseLanguageModelStrategy<
    * @returns Parser callback, or undefined to disable per-part plumbing.
    * @internal
    */
-  protected getPartProviderOptionsParser():
-    | ((
-        providerOptions: unknown,
-      ) => undefined | { readonly cacheControl?: { ttl?: "1h" | "5m"; type: "ephemeral" } })
-    | undefined {
+  protected getPartProviderOptionsParser(): ParsePartProviderOptions | undefined {
     return undefined;
   }
 

--- a/src/base-language-model-strategy.ts
+++ b/src/base-language-model-strategy.ts
@@ -21,6 +21,8 @@ import {
   buildModelParams,
   createAISDKRequestBodySummary,
   createStreamTransformer,
+  extractCompletionId,
+  extractResponseMetadata,
   mapToolChoice,
   type ParamMapping,
   type SAPToolChoice,
@@ -315,6 +317,35 @@ export abstract class BaseLanguageModelStrategy<
     abortSignal: AbortSignal | undefined,
     settings: TSettings,
   ): Promise<StreamCallResponse>;
+
+  /**
+   * Resolves request id, completion id, and normalised headers from an SDK
+   * response in one place. Used by `executeApiCall` and `executeStreamCall`
+   * overrides so each call site goes through the same extraction pipeline.
+   * @param response - Raw SDK response or stream response.
+   * @returns Combined metadata fragment.
+   * @internal
+   */
+  protected extractMetadata(response: unknown): {
+    requestId?: string;
+    responseHeaders?: Record<string, string>;
+    responseId?: string;
+  } {
+    const responseId = extractCompletionId(
+      response as { _data?: unknown; getRequestId?: () => string | undefined },
+      this.getCompletionIdPath(),
+    );
+    const { headers, requestId } = extractResponseMetadata(response, "rawResponse");
+    return { requestId, responseHeaders: headers, responseId };
+  }
+
+  /**
+   * Returns the API-specific dotted path used to read the completion id off
+   * the SDK response's internal `_data` payload.
+   * @returns Path traversed under `_data` (e.g. `["final_result","id"]`, `["id"]`).
+   * @internal
+   */
+  protected abstract getCompletionIdPath(): readonly string[];
 
   /**
    * Returns whether to escape template placeholders for this API.

--- a/src/convert-to-sap-messages.test.ts
+++ b/src/convert-to-sap-messages.test.ts
@@ -1585,7 +1585,8 @@ describe("convertToSAPMessages", () => {
       convertToSAPMessages(prompt, { parsePartProviderOptions, warnings });
 
       expect(warnings).toContainEqual({
-        details: "SAP orchestration does not expose cache_control on assistant tool calls.",
+        details:
+          "SAP orchestration does not expose cache_control on the assistant tool-call envelope.",
         feature: "cacheControl on assistant tool-call",
         type: "unsupported",
       });

--- a/src/convert-to-sap-messages.test.ts
+++ b/src/convert-to-sap-messages.test.ts
@@ -1484,6 +1484,26 @@ describe("convertToSAPMessages", () => {
       expect(assistantMsg.content).toBe("first second");
     });
 
+    it("should drop empty-text assistant parts even when cacheControl is set", () => {
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [
+            {
+              providerOptions: { "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } } },
+              text: "",
+              type: "text",
+            },
+            { text: "kept", type: "text" },
+          ],
+          role: "assistant",
+        },
+      ];
+      const result = convertToSAPMessages(prompt, { parsePartProviderOptions });
+      const assistantMsg = result[0] as { content: unknown };
+      expect(typeof assistantMsg.content).toBe("string");
+      expect(assistantMsg.content).toBe("kept");
+    });
+
     it("should surface an unsupported warning when cacheControl is set on an assistant tool-call", () => {
       const warnings: SharedV3Warning[] = [];
       const prompt: LanguageModelV3Prompt = [

--- a/src/convert-to-sap-messages.test.ts
+++ b/src/convert-to-sap-messages.test.ts
@@ -1584,10 +1584,11 @@ describe("convertToSAPMessages", () => {
       ];
       convertToSAPMessages(prompt, { parsePartProviderOptions, warnings });
 
-      const cacheToolWarning = warnings.find((w) =>
-        ((w as { feature?: string }).feature ?? "").includes("tool-call"),
-      );
-      expect(cacheToolWarning).toMatchObject({ type: "unsupported" });
+      expect(warnings).toContainEqual({
+        details: "SAP orchestration does not expose cache_control on assistant tool calls.",
+        feature: "cacheControl on assistant tool-call",
+        type: "unsupported",
+      });
     });
 
     it("should attach cache_control to a tool-result message", () => {

--- a/src/convert-to-sap-messages.test.ts
+++ b/src/convert-to-sap-messages.test.ts
@@ -1390,5 +1390,163 @@ describe("convertToSAPMessages", () => {
 
       expect(warnings).toHaveLength(0);
     });
+
+    it("attaches cache_control to a system message via message-level providerOptions", () => {
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: "You are helpful.",
+          providerOptions: { "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } } },
+          role: "system",
+        },
+      ];
+      const result = convertToSAPMessages(prompt, { parsePartProviderOptions });
+      const systemMsg = result[0] as {
+        content: { cache_control?: unknown; text: string; type: string }[];
+      };
+      expect(Array.isArray(systemMsg.content)).toBe(true);
+      expect(systemMsg.content[0]).toEqual({
+        cache_control: { ttl: "5m", type: "ephemeral" },
+        text: "You are helpful.",
+        type: "text",
+      });
+    });
+
+    it("keeps system message content as a string when no cacheControl is set", () => {
+      const prompt: LanguageModelV3Prompt = [{ content: "no cache", role: "system" }];
+      const result = convertToSAPMessages(prompt, { parsePartProviderOptions });
+      const systemMsg = result[0] as { content: unknown };
+      expect(typeof systemMsg.content).toBe("string");
+      expect(systemMsg.content).toBe("no cache");
+    });
+
+    it("attaches cache_control to an assistant text part", () => {
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [
+            {
+              providerOptions: { "sap-ai": { cacheControl: { ttl: "1h", type: "ephemeral" } } },
+              text: "Cached answer.",
+              type: "text",
+            },
+          ],
+          role: "assistant",
+        },
+      ];
+      const result = convertToSAPMessages(prompt, { parsePartProviderOptions });
+      const assistantMsg = result[0] as {
+        content: { cache_control?: unknown; text: string; type: string }[];
+      };
+      expect(Array.isArray(assistantMsg.content)).toBe(true);
+      expect(assistantMsg.content[0]).toEqual({
+        cache_control: { ttl: "1h", type: "ephemeral" },
+        text: "Cached answer.",
+        type: "text",
+      });
+    });
+
+    it("preserves order across cached and uncached assistant text parts", () => {
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [
+            {
+              providerOptions: { "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } } },
+              text: "first",
+              type: "text",
+            },
+            { text: "second", type: "text" },
+          ],
+          role: "assistant",
+        },
+      ];
+      const result = convertToSAPMessages(prompt, { parsePartProviderOptions });
+      const assistantMsg = result[0] as {
+        content: { cache_control?: unknown; text: string }[];
+      };
+      expect(assistantMsg.content).toEqual([
+        { cache_control: { ttl: "5m", type: "ephemeral" }, text: "first", type: "text" },
+        { text: "second", type: "text" },
+      ]);
+    });
+
+    it("keeps assistant content as a string when no part declares cacheControl", () => {
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [
+            { text: "first", type: "text" },
+            { text: " second", type: "text" },
+          ],
+          role: "assistant",
+        },
+      ];
+      const result = convertToSAPMessages(prompt, { parsePartProviderOptions });
+      const assistantMsg = result[0] as { content: unknown };
+      expect(typeof assistantMsg.content).toBe("string");
+      expect(assistantMsg.content).toBe("first second");
+    });
+
+    it("surfaces an unsupported warning when cacheControl is set on an assistant tool-call", () => {
+      const warnings: SharedV3Warning[] = [];
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [
+            { text: "calling tool", type: "text" },
+            {
+              input: { q: "weather" },
+              providerOptions: { "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } } },
+              toolCallId: "c1",
+              toolName: "lookup",
+              type: "tool-call",
+            },
+          ],
+          role: "assistant",
+        },
+      ];
+      convertToSAPMessages(prompt, { parsePartProviderOptions, warnings });
+
+      const cacheToolWarning = warnings.find((w) =>
+        ((w as { feature?: string }).feature ?? "").includes("tool-call"),
+      );
+      expect(cacheToolWarning).toMatchObject({ type: "unsupported" });
+    });
+
+    it("attaches cache_control to a tool-result message", () => {
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [
+            {
+              output: { type: "json", value: { ok: true } },
+              providerOptions: { "sap-ai": { cacheControl: { ttl: "1h", type: "ephemeral" } } },
+              toolCallId: "c1",
+              toolName: "lookup",
+              type: "tool-result",
+            },
+          ],
+          role: "tool",
+        },
+      ];
+      const result = convertToSAPMessages(prompt, { parsePartProviderOptions });
+      const toolMsg = result[0] as { content: { cache_control?: unknown; text: string }[] };
+      expect(Array.isArray(toolMsg.content)).toBe(true);
+      expect(toolMsg.content[0]?.cache_control).toEqual({ ttl: "1h", type: "ephemeral" });
+    });
+
+    it("keeps tool-result content as a string when no cacheControl is set", () => {
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [
+            {
+              output: { type: "json", value: { ok: true } },
+              toolCallId: "c1",
+              toolName: "lookup",
+              type: "tool-result",
+            },
+          ],
+          role: "tool",
+        },
+      ];
+      const result = convertToSAPMessages(prompt, { parsePartProviderOptions });
+      const toolMsg = result[0] as { content: unknown };
+      expect(typeof toolMsg.content).toBe("string");
+    });
   });
 });

--- a/src/convert-to-sap-messages.test.ts
+++ b/src/convert-to-sap-messages.test.ts
@@ -2,7 +2,7 @@
  * Tests conversion from Vercel AI SDK prompt format to SAP AI SDK ChatMessage format.
  * @see convertToSAPMessages
  */
-import type { LanguageModelV3Prompt } from "@ai-sdk/provider";
+import type { LanguageModelV3Prompt, SharedV3Warning } from "@ai-sdk/provider";
 
 import { InvalidPromptError } from "@ai-sdk/provider";
 import { Buffer } from "node:buffer";
@@ -1347,6 +1347,48 @@ describe("convertToSAPMessages", () => {
       const result = convertToSAPMessages(prompt);
       const userMsg = result[0] as { content: unknown };
       expect(typeof userMsg.content).toBe("string");
+    });
+
+    it("surfaces parser warnings into the warnings sink when an invalid cacheControl block is provided", () => {
+      const warnings: SharedV3Warning[] = [];
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [
+            {
+              providerOptions: { "sap-ai": { cacheControl: { ttl: "10m", type: "ephemeral" } } },
+              text: "x",
+              type: "text",
+            },
+          ],
+          role: "user",
+        },
+      ];
+      const result = convertToSAPMessages(prompt, { parsePartProviderOptions, warnings });
+      const userMsg = result[0] as { content: unknown };
+
+      expect(typeof userMsg.content).toBe("string");
+      expect(warnings.length).toBeGreaterThan(0);
+      expect(warnings[0]).toMatchObject({ type: "other" });
+      expect((warnings[0] as { message?: string }).message ?? "").toMatch(/cacheControl/);
+    });
+
+    it("does not push warnings when cacheControl is valid", () => {
+      const warnings: SharedV3Warning[] = [];
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [
+            {
+              providerOptions: { "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } } },
+              text: "x",
+              type: "text",
+            },
+          ],
+          role: "user",
+        },
+      ];
+      convertToSAPMessages(prompt, { parsePartProviderOptions, warnings });
+
+      expect(warnings).toHaveLength(0);
     });
   });
 });

--- a/src/convert-to-sap-messages.test.ts
+++ b/src/convert-to-sap-messages.test.ts
@@ -1234,4 +1234,126 @@ describe("convertToSAPMessages", () => {
       });
     });
   });
+
+  describe("cache_control plumbing", () => {
+    const parsePartProviderOptions = (
+      providerOptions: unknown,
+    ): undefined | { readonly cacheControl?: { ttl?: "1h" | "5m"; type: "ephemeral" } } => {
+      if (!providerOptions || typeof providerOptions !== "object") return undefined;
+      const block = (providerOptions as Record<string, unknown>)["sap-ai"];
+      return block as
+        | undefined
+        | { readonly cacheControl?: { ttl?: "1h" | "5m"; type: "ephemeral" } };
+    };
+
+    it("attaches cache_control to a user text part when cacheControl is set", () => {
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [
+            {
+              providerOptions: { "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } } },
+              text: "Cache me",
+              type: "text",
+            },
+            { text: "Don't cache me", type: "text" },
+          ],
+          role: "user",
+        },
+      ];
+      const result = convertToSAPMessages(prompt, { parsePartProviderOptions });
+      const userMsg = result[0] as {
+        content: { cache_control?: unknown; text: string; type: string }[];
+      };
+      expect(userMsg.content[0]?.cache_control).toEqual({ ttl: "5m", type: "ephemeral" });
+      expect(userMsg.content[1]?.cache_control).toBeUndefined();
+    });
+
+    it("attaches cache_control to a user image_url part", () => {
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [
+            {
+              data: "base64data",
+              mediaType: "image/png",
+              providerOptions: { "sap-ai": { cacheControl: { ttl: "1h", type: "ephemeral" } } },
+              type: "file",
+            },
+          ],
+          role: "user",
+        },
+      ];
+      const result = convertToSAPMessages(prompt, { parsePartProviderOptions });
+      const userMsg = result[0] as { content: { cache_control?: unknown; type: string }[] };
+      expect(userMsg.content[0]?.cache_control).toEqual({ ttl: "1h", type: "ephemeral" });
+    });
+
+    it("does not collapse a single-text user message to string form when cache_control is set", () => {
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [
+            {
+              providerOptions: { "sap-ai": { cacheControl: { type: "ephemeral" } } },
+              text: "with cache",
+              type: "text",
+            },
+          ],
+          role: "user",
+        },
+      ];
+      const result = convertToSAPMessages(prompt, { parsePartProviderOptions });
+      const userMsg = result[0] as { content: unknown };
+      expect(Array.isArray(userMsg.content)).toBe(true);
+    });
+
+    it("collapses a single-text user message to string form when cache_control is absent", () => {
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [{ text: "no cache", type: "text" }],
+          role: "user",
+        },
+      ];
+      const result = convertToSAPMessages(prompt, { parsePartProviderOptions });
+      const userMsg = result[0] as { content: unknown };
+      expect(typeof userMsg.content).toBe("string");
+      expect(userMsg.content).toBe("no cache");
+    });
+
+    it("ignores cacheControl scoped to another provider key", () => {
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [
+            {
+              providerOptions: {
+                anthropic: { cacheControl: { ttl: "5m", type: "ephemeral" } },
+              },
+              text: "x",
+              type: "text",
+            },
+          ],
+          role: "user",
+        },
+      ];
+      const result = convertToSAPMessages(prompt, { parsePartProviderOptions });
+      const userMsg = result[0] as { content: unknown };
+      expect(typeof userMsg.content).toBe("string");
+    });
+
+    it("never attaches cache_control when no parsePartProviderOptions callback is supplied", () => {
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [
+            {
+              providerOptions: { "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } } },
+              text: "x",
+              type: "text",
+            },
+          ],
+          role: "user",
+        },
+      ];
+      const result = convertToSAPMessages(prompt);
+      const userMsg = result[0] as { content: unknown };
+      expect(typeof userMsg.content).toBe("string");
+    });
+  });
 });

--- a/src/convert-to-sap-messages.test.ts
+++ b/src/convert-to-sap-messages.test.ts
@@ -1504,7 +1504,7 @@ describe("convertToSAPMessages", () => {
       expect(assistantMsg.content).toBe("kept");
     });
 
-    it("should emit a single Zod warning when N parts share the same invalid cacheControl", () => {
+    it("should emit a single Zod warning when multiple parts share the same invalid cacheControl", () => {
       const warnings: SharedV3Warning[] = [];
       const invalid = { "sap-ai": { cacheControl: { ttl: "10m", type: "ephemeral" } } };
       const prompt: LanguageModelV3Prompt = [
@@ -1524,7 +1524,7 @@ describe("convertToSAPMessages", () => {
       expect(cacheControlIssues).toHaveLength(1);
     });
 
-    it("should emit a single unsupported warning when N tool-call parts carry cacheControl", () => {
+    it("should emit a single unsupported warning when multiple tool-call parts carry cacheControl", () => {
       const warnings: SharedV3Warning[] = [];
       const cacheOpts = {
         "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" as const } },

--- a/src/convert-to-sap-messages.test.ts
+++ b/src/convert-to-sap-messages.test.ts
@@ -1239,7 +1239,7 @@ describe("convertToSAPMessages", () => {
   describe("cache_control plumbing", () => {
     const parsePartProviderOptions = parseSAPPartProviderOptions;
 
-    it("attaches cache_control to a user text part when cacheControl is set", () => {
+    it("should attach cache_control to a user text part when cacheControl is set", () => {
       const prompt: LanguageModelV3Prompt = [
         {
           content: [
@@ -1261,7 +1261,7 @@ describe("convertToSAPMessages", () => {
       expect(userMsg.content[1]?.cache_control).toBeUndefined();
     });
 
-    it("attaches cache_control to a user image_url part", () => {
+    it("should attach cache_control to a user image_url part", () => {
       const prompt: LanguageModelV3Prompt = [
         {
           content: [
@@ -1280,7 +1280,7 @@ describe("convertToSAPMessages", () => {
       expect(userMsg.content[0]?.cache_control).toEqual({ ttl: "1h", type: "ephemeral" });
     });
 
-    it("does not collapse a single-text user message to string form when cache_control is set", () => {
+    it("should not collapse a single-text user message to string form when cache_control is set", () => {
       const prompt: LanguageModelV3Prompt = [
         {
           content: [
@@ -1298,7 +1298,7 @@ describe("convertToSAPMessages", () => {
       expect(Array.isArray(userMsg.content)).toBe(true);
     });
 
-    it("collapses a single-text user message to string form when cache_control is absent", () => {
+    it("should collapse a single-text user message to string form when cache_control is absent", () => {
       const prompt: LanguageModelV3Prompt = [
         {
           content: [{ text: "no cache", type: "text" }],
@@ -1311,7 +1311,7 @@ describe("convertToSAPMessages", () => {
       expect(userMsg.content).toBe("no cache");
     });
 
-    it("ignores cacheControl scoped to another provider key", () => {
+    it("should ignore cacheControl scoped to another provider key", () => {
       const prompt: LanguageModelV3Prompt = [
         {
           content: [
@@ -1331,7 +1331,7 @@ describe("convertToSAPMessages", () => {
       expect(typeof userMsg.content).toBe("string");
     });
 
-    it("never attaches cache_control when no parsePartProviderOptions callback is supplied", () => {
+    it("should never attach cache_control when no parsePartProviderOptions callback is supplied", () => {
       const prompt: LanguageModelV3Prompt = [
         {
           content: [
@@ -1349,7 +1349,7 @@ describe("convertToSAPMessages", () => {
       expect(typeof userMsg.content).toBe("string");
     });
 
-    it("surfaces parser warnings into the warnings sink when an invalid cacheControl block is provided", () => {
+    it("should surface parser warnings into the warnings sink when an invalid cacheControl block is provided", () => {
       const warnings: SharedV3Warning[] = [];
       const prompt: LanguageModelV3Prompt = [
         {
@@ -1372,7 +1372,7 @@ describe("convertToSAPMessages", () => {
       expect((warnings[0] as { message?: string }).message ?? "").toMatch(/cacheControl/);
     });
 
-    it("does not push warnings when cacheControl is valid", () => {
+    it("should not push warnings when cacheControl is valid", () => {
       const warnings: SharedV3Warning[] = [];
       const prompt: LanguageModelV3Prompt = [
         {
@@ -1391,7 +1391,7 @@ describe("convertToSAPMessages", () => {
       expect(warnings).toHaveLength(0);
     });
 
-    it("attaches cache_control to a system message via message-level providerOptions", () => {
+    it("should attach cache_control to a system message via message-level providerOptions", () => {
       const prompt: LanguageModelV3Prompt = [
         {
           content: "You are helpful.",
@@ -1411,7 +1411,7 @@ describe("convertToSAPMessages", () => {
       });
     });
 
-    it("keeps system message content as a string when no cacheControl is set", () => {
+    it("should keep system message content as a string when no cacheControl is set", () => {
       const prompt: LanguageModelV3Prompt = [{ content: "no cache", role: "system" }];
       const result = convertToSAPMessages(prompt, { parsePartProviderOptions });
       const systemMsg = result[0] as { content: unknown };
@@ -1419,7 +1419,7 @@ describe("convertToSAPMessages", () => {
       expect(systemMsg.content).toBe("no cache");
     });
 
-    it("attaches cache_control to an assistant text part", () => {
+    it("should attach cache_control to an assistant text part", () => {
       const prompt: LanguageModelV3Prompt = [
         {
           content: [
@@ -1444,7 +1444,7 @@ describe("convertToSAPMessages", () => {
       });
     });
 
-    it("preserves order across cached and uncached assistant text parts", () => {
+    it("should preserve order across cached and uncached assistant text parts", () => {
       const prompt: LanguageModelV3Prompt = [
         {
           content: [
@@ -1468,7 +1468,7 @@ describe("convertToSAPMessages", () => {
       ]);
     });
 
-    it("keeps assistant content as a string when no part declares cacheControl", () => {
+    it("should keep assistant content as a string when no part declares cacheControl", () => {
       const prompt: LanguageModelV3Prompt = [
         {
           content: [
@@ -1484,7 +1484,7 @@ describe("convertToSAPMessages", () => {
       expect(assistantMsg.content).toBe("first second");
     });
 
-    it("surfaces an unsupported warning when cacheControl is set on an assistant tool-call", () => {
+    it("should surface an unsupported warning when cacheControl is set on an assistant tool-call", () => {
       const warnings: SharedV3Warning[] = [];
       const prompt: LanguageModelV3Prompt = [
         {
@@ -1509,7 +1509,7 @@ describe("convertToSAPMessages", () => {
       expect(cacheToolWarning).toMatchObject({ type: "unsupported" });
     });
 
-    it("attaches cache_control to a tool-result message", () => {
+    it("should attach cache_control to a tool-result message", () => {
       const prompt: LanguageModelV3Prompt = [
         {
           content: [
@@ -1530,7 +1530,7 @@ describe("convertToSAPMessages", () => {
       expect(toolMsg.content[0]?.cache_control).toEqual({ ttl: "1h", type: "ephemeral" });
     });
 
-    it("keeps tool-result content as a string when no cacheControl is set", () => {
+    it("should keep tool-result content as a string when no cacheControl is set", () => {
       const prompt: LanguageModelV3Prompt = [
         {
           content: [

--- a/src/convert-to-sap-messages.test.ts
+++ b/src/convert-to-sap-messages.test.ts
@@ -13,6 +13,7 @@ import {
   escapeOrchestrationPlaceholders,
   unescapeOrchestrationPlaceholders,
 } from "./convert-to-sap-messages";
+import { parseSAPPartProviderOptions } from "./sap-ai-provider-options.js";
 
 const createUserPrompt = (text: string): LanguageModelV3Prompt => [
   { content: [{ text, type: "text" }], role: "user" },
@@ -1236,15 +1237,7 @@ describe("convertToSAPMessages", () => {
   });
 
   describe("cache_control plumbing", () => {
-    const parsePartProviderOptions = (
-      providerOptions: unknown,
-    ): undefined | { readonly cacheControl?: { ttl?: "1h" | "5m"; type: "ephemeral" } } => {
-      if (!providerOptions || typeof providerOptions !== "object") return undefined;
-      const block = (providerOptions as Record<string, unknown>)["sap-ai"];
-      return block as
-        | undefined
-        | { readonly cacheControl?: { ttl?: "1h" | "5m"; type: "ephemeral" } };
-    };
+    const parsePartProviderOptions = parseSAPPartProviderOptions;
 
     it("attaches cache_control to a user text part when cacheControl is set", () => {
       const prompt: LanguageModelV3Prompt = [

--- a/src/convert-to-sap-messages.test.ts
+++ b/src/convert-to-sap-messages.test.ts
@@ -1504,6 +1504,67 @@ describe("convertToSAPMessages", () => {
       expect(assistantMsg.content).toBe("kept");
     });
 
+    it("should emit a single Zod warning when N parts share the same invalid cacheControl", () => {
+      const warnings: SharedV3Warning[] = [];
+      const invalid = { "sap-ai": { cacheControl: { ttl: "10m", type: "ephemeral" } } };
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [
+            { providerOptions: invalid, text: "a", type: "text" },
+            { providerOptions: invalid, text: "b", type: "text" },
+            { providerOptions: invalid, text: "c", type: "text" },
+          ],
+          role: "user",
+        },
+      ];
+      convertToSAPMessages(prompt, { parsePartProviderOptions, warnings });
+      const cacheControlIssues = warnings.filter((w) =>
+        ((w as { message?: string }).message ?? "").includes("cacheControl"),
+      );
+      expect(cacheControlIssues).toHaveLength(1);
+    });
+
+    it("should emit a single unsupported warning when N tool-call parts carry cacheControl", () => {
+      const warnings: SharedV3Warning[] = [];
+      const cacheOpts = {
+        "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" as const } },
+      };
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [
+            { text: "calling", type: "text" },
+            {
+              input: { q: "a" },
+              providerOptions: cacheOpts,
+              toolCallId: "c1",
+              toolName: "lookup",
+              type: "tool-call",
+            },
+            {
+              input: { q: "b" },
+              providerOptions: cacheOpts,
+              toolCallId: "c2",
+              toolName: "lookup",
+              type: "tool-call",
+            },
+            {
+              input: { q: "c" },
+              providerOptions: cacheOpts,
+              toolCallId: "c3",
+              toolName: "lookup",
+              type: "tool-call",
+            },
+          ],
+          role: "assistant",
+        },
+      ];
+      convertToSAPMessages(prompt, { parsePartProviderOptions, warnings });
+      const toolCallWarnings = warnings.filter((w) =>
+        ((w as { feature?: string }).feature ?? "").includes("tool-call"),
+      );
+      expect(toolCallWarnings).toHaveLength(1);
+    });
+
     it("should surface an unsupported warning when cacheControl is set on an assistant tool-call", () => {
       const warnings: SharedV3Warning[] = [];
       const prompt: LanguageModelV3Prompt = [

--- a/src/convert-to-sap-messages.ts
+++ b/src/convert-to-sap-messages.ts
@@ -192,7 +192,7 @@ export function convertToSAPMessages(
                 ) {
                   options.warnings.push({
                     details:
-                      "SAP orchestration does not expose cache_control on assistant tool calls.",
+                      "SAP orchestration does not expose cache_control on the assistant tool-call envelope.",
                     feature,
                     type: "unsupported",
                   });

--- a/src/convert-to-sap-messages.ts
+++ b/src/convert-to-sap-messages.ts
@@ -143,6 +143,11 @@ export function convertToSAPMessages(
   const maybeEscape = (text: string): string =>
     escapeTemplatePlaceholders ? escapeOrchestrationPlaceholders(text) : text;
 
+  const parser = options.parsePartProviderOptions;
+  const parsePart = parser
+    ? (providerOptions: unknown) => parser(providerOptions, options.warnings)
+    : () => undefined;
+
   for (const message of prompt) {
     switch (message.role) {
       case "assistant": {
@@ -171,10 +176,7 @@ export function convertToSAPMessages(
             case "text": {
               const escaped = maybeEscape(part.text);
               if (!escaped) break;
-              const partOpts = options.parsePartProviderOptions?.(
-                part.providerOptions,
-                options.warnings,
-              );
+              const partOpts = parsePart(part.providerOptions);
               const cacheControl = partOpts?.cacheControl;
               text += escaped;
               textParts.push(cacheControl ? { cacheControl, text: escaped } : { text: escaped });
@@ -182,10 +184,7 @@ export function convertToSAPMessages(
               break;
             }
             case "tool-call": {
-              const partOpts = options.parsePartProviderOptions?.(
-                part.providerOptions,
-                options.warnings,
-              );
+              const partOpts = parsePart(part.providerOptions);
               if (partOpts?.cacheControl && options.warnings) {
                 const feature = "cacheControl on assistant tool-call";
                 if (
@@ -235,10 +234,7 @@ export function convertToSAPMessages(
       }
 
       case "system": {
-        const partOpts = options.parsePartProviderOptions?.(
-          message.providerOptions,
-          options.warnings,
-        );
+        const partOpts = parsePart(message.providerOptions);
         const cacheControl = partOpts?.cacheControl;
         const text = maybeEscape(message.content);
         const systemMessage: SystemChatMessage = {
@@ -252,10 +248,7 @@ export function convertToSAPMessages(
       case "tool": {
         for (const part of message.content) {
           if (part.type === "tool-result") {
-            const partOpts = options.parsePartProviderOptions?.(
-              part.providerOptions,
-              options.warnings,
-            );
+            const partOpts = parsePart(part.providerOptions);
             const cacheControl = partOpts?.cacheControl;
             const serializedOutput = safeJsonStringify(part.output);
             const escaped = maybeEscape(serializedOutput);
@@ -274,10 +267,7 @@ export function convertToSAPMessages(
         const contentParts: UserContentItem[] = [];
 
         for (const part of message.content) {
-          const partOpts = options.parsePartProviderOptions?.(
-            part.providerOptions,
-            options.warnings,
-          );
+          const partOpts = parsePart(part.providerOptions);
           const cacheControl = partOpts?.cacheControl;
           switch (part.type) {
             case "file": {

--- a/src/convert-to-sap-messages.ts
+++ b/src/convert-to-sap-messages.ts
@@ -75,9 +75,10 @@ function safeJsonStringify(value: unknown): string {
 }
 
 /**
+ * Wraps a text payload as a SAP `TextContent` block, attaching `cache_control` when set.
  * @param text - Pre-escaped text payload.
  * @param cacheControl - Optional Anthropic prompt-cache directive.
- * @returns SAP `TextContent` block, with `cache_control` attached when the directive is set.
+ * @returns SAP `TextContent` block.
  */
 function wrapAsTextContent(
   text: string,

--- a/src/convert-to-sap-messages.ts
+++ b/src/convert-to-sap-messages.ts
@@ -79,6 +79,11 @@ function safeJsonStringify(value: unknown): string {
  * @param text
  * @param cacheControl
  */
+/**
+ * @param text - Pre-escaped text payload.
+ * @param cacheControl - Optional Anthropic prompt-cache directive.
+ * @returns SAP `TextContent` block, with `cache_control` attached when the directive is set.
+ */
 function wrapAsTextContent(
   text: string,
   cacheControl: CacheControl | undefined,

--- a/src/convert-to-sap-messages.ts
+++ b/src/convert-to-sap-messages.ts
@@ -14,7 +14,7 @@ import {
 } from "@ai-sdk/provider";
 import { Buffer } from "node:buffer";
 
-import type { ParsePartProviderOptions } from "./sap-ai-provider-options.js";
+import type { CacheControl, ParsePartProviderOptions } from "./sap-ai-provider-options.js";
 
 /**
  * Options for converting Vercel AI SDK prompts to SAP AI SDK messages.
@@ -72,6 +72,20 @@ function safeJsonStringify(value: unknown): string {
   } catch {
     return String(value);
   }
+}
+
+/**
+ *
+ * @param text
+ * @param cacheControl
+ */
+function wrapAsTextContent(
+  text: string,
+  cacheControl: CacheControl | undefined,
+): { cache_control?: CacheControl; text: string; type: "text" } {
+  return cacheControl
+    ? { cache_control: cacheControl, text, type: "text" }
+    : { text, type: "text" };
 }
 
 /**
@@ -210,11 +224,7 @@ export function convertToSAPMessages(
         if (text || toolCalls.length > 0) {
           const assistantMessage: AssistantChatMessage = {
             content: anyCacheControl
-              ? textParts.map((p) =>
-                  p.cacheControl
-                    ? { cache_control: p.cacheControl, text: p.text, type: "text" as const }
-                    : { text: p.text, type: "text" as const },
-                )
+              ? textParts.map((p) => wrapAsTextContent(p.text, p.cacheControl))
               : text,
             role: "assistant",
             tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
@@ -232,9 +242,7 @@ export function convertToSAPMessages(
         const cacheControl = partOpts?.cacheControl;
         const text = maybeEscape(message.content);
         const systemMessage: SystemChatMessage = {
-          content: cacheControl
-            ? [{ cache_control: cacheControl, text, type: "text" as const }]
-            : text,
+          content: cacheControl ? [wrapAsTextContent(text, cacheControl)] : text,
           role: "system",
         };
         messages.push(systemMessage);
@@ -252,9 +260,7 @@ export function convertToSAPMessages(
             const serializedOutput = safeJsonStringify(part.output);
             const escaped = maybeEscape(serializedOutput);
             const toolMessage: ToolChatMessage = {
-              content: cacheControl
-                ? [{ cache_control: cacheControl, text: escaped, type: "text" as const }]
-                : escaped,
+              content: cacheControl ? [wrapAsTextContent(escaped, cacheControl)] : escaped,
               role: "tool",
               tool_call_id: part.toolCallId,
             };

--- a/src/convert-to-sap-messages.ts
+++ b/src/convert-to-sap-messages.ts
@@ -13,6 +13,8 @@ import {
 } from "@ai-sdk/provider";
 import { Buffer } from "node:buffer";
 
+import type { ParsePartProviderOptions } from "./sap-ai-provider-options.js";
+
 /**
  * Options for converting Vercel AI SDK prompts to SAP AI SDK messages.
  * @see {@link convertToSAPMessages}
@@ -35,9 +37,7 @@ export interface ConvertToSAPMessagesOptions {
    * do not honour part-level directives (Foundation Models) leave this undefined.
    * @default undefined
    */
-  readonly parsePartProviderOptions?: (
-    providerOptions: unknown,
-  ) => undefined | { readonly cacheControl?: { ttl?: "1h" | "5m"; type: "ephemeral" } };
+  readonly parsePartProviderOptions?: ParsePartProviderOptions;
 }
 
 /**
@@ -104,6 +104,7 @@ interface UserContentItem {
  * @param options - Conversion options.
  * @param options.escapeTemplatePlaceholders - Whether to escape Jinja2 template delimiters (default: true).
  * @param options.includeReasoning - Whether to include assistant reasoning parts (default: false).
+ * @param options.parsePartProviderOptions - Optional callback to read per-part `providerOptions['sap-ai']`. Strategies opt in to honour part-level directives such as Anthropic `cacheControl`.
  * @returns SAP AI SDK ChatMessage array ready for orchestration requests.
  * @throws {UnsupportedFunctionalityError} When encountering unsupported content types or file formats.
  * @throws {InvalidPromptError} When encountering unsupported message roles.

--- a/src/convert-to-sap-messages.ts
+++ b/src/convert-to-sap-messages.ts
@@ -75,11 +75,6 @@ function safeJsonStringify(value: unknown): string {
 }
 
 /**
- *
- * @param text
- * @param cacheControl
- */
-/**
  * @param text - Pre-escaped text payload.
  * @param cacheControl - Optional Anthropic prompt-cache directive.
  * @returns SAP `TextContent` block, with `cache_control` attached when the directive is set.

--- a/src/convert-to-sap-messages.ts
+++ b/src/convert-to-sap-messages.ts
@@ -133,6 +133,11 @@ export function convertToSAPMessages(
     switch (message.role) {
       case "assistant": {
         let text = "";
+        const textParts: {
+          cacheControl?: { ttl?: "1h" | "5m"; type: "ephemeral" };
+          text: string;
+        }[] = [];
+        let anyCacheControl = false;
         const toolCalls: {
           function: { arguments: string; name: string };
           id: string;
@@ -143,15 +148,37 @@ export function convertToSAPMessages(
           switch (part.type) {
             case "reasoning": {
               if (includeReasoning && part.text) {
-                text += `<think>${maybeEscape(part.text)}</think>`;
+                const escaped = `<think>${maybeEscape(part.text)}</think>`;
+                text += escaped;
+                textParts.push({ text: escaped });
               }
               break;
             }
             case "text": {
-              text += maybeEscape(part.text);
+              const partOpts = options.parsePartProviderOptions?.(
+                part.providerOptions,
+                options.warnings,
+              );
+              const cacheControl = partOpts?.cacheControl;
+              const escaped = maybeEscape(part.text);
+              text += escaped;
+              textParts.push(cacheControl ? { cacheControl, text: escaped } : { text: escaped });
+              if (cacheControl) anyCacheControl = true;
               break;
             }
             case "tool-call": {
+              const partOpts = options.parsePartProviderOptions?.(
+                part.providerOptions,
+                options.warnings,
+              );
+              if (partOpts?.cacheControl && options.warnings) {
+                options.warnings.push({
+                  details:
+                    "SAP orchestration does not expose cache_control on assistant tool calls.",
+                  feature: "cacheControl on assistant tool-call",
+                  type: "unsupported",
+                });
+              }
               // Normalize tool call input to JSON string (Vercel AI SDK provides strings or objects)
               let argumentsJson: string;
               if (typeof part.input === "string") {
@@ -176,7 +203,13 @@ export function convertToSAPMessages(
 
         if (text || toolCalls.length > 0) {
           const assistantMessage: AssistantChatMessage = {
-            content: text,
+            content: anyCacheControl
+              ? textParts.map((p) =>
+                  p.cacheControl
+                    ? { cache_control: p.cacheControl, text: p.text, type: "text" as const }
+                    : { text: p.text, type: "text" as const },
+                )
+              : text,
             role: "assistant",
             tool_calls: toolCalls.length > 0 ? toolCalls : undefined,
           };
@@ -186,8 +219,16 @@ export function convertToSAPMessages(
       }
 
       case "system": {
+        const partOpts = options.parsePartProviderOptions?.(
+          message.providerOptions,
+          options.warnings,
+        );
+        const cacheControl = partOpts?.cacheControl;
+        const text = maybeEscape(message.content);
         const systemMessage: SystemChatMessage = {
-          content: maybeEscape(message.content),
+          content: cacheControl
+            ? [{ cache_control: cacheControl, text, type: "text" as const }]
+            : text,
           role: "system",
         };
         messages.push(systemMessage);
@@ -197,9 +238,17 @@ export function convertToSAPMessages(
       case "tool": {
         for (const part of message.content) {
           if (part.type === "tool-result") {
+            const partOpts = options.parsePartProviderOptions?.(
+              part.providerOptions,
+              options.warnings,
+            );
+            const cacheControl = partOpts?.cacheControl;
             const serializedOutput = safeJsonStringify(part.output);
+            const escaped = maybeEscape(serializedOutput);
             const toolMessage: ToolChatMessage = {
-              content: maybeEscape(serializedOutput),
+              content: cacheControl
+                ? [{ cache_control: cacheControl, text: escaped, type: "text" as const }]
+                : escaped,
               role: "tool",
               tool_call_id: part.toolCallId,
             };

--- a/src/convert-to-sap-messages.ts
+++ b/src/convert-to-sap-messages.ts
@@ -9,6 +9,7 @@ import type {
 import {
   InvalidPromptError,
   LanguageModelV3Prompt,
+  type SharedV3Warning,
   UnsupportedFunctionalityError,
 } from "@ai-sdk/provider";
 import { Buffer } from "node:buffer";
@@ -38,6 +39,13 @@ export interface ConvertToSAPMessagesOptions {
    * @default undefined
    */
   readonly parsePartProviderOptions?: ParsePartProviderOptions;
+  /**
+   * Optional sink for validation warnings raised by `parsePartProviderOptions`.
+   * Each invalid `cacheControl` directive (or other future per-part option)
+   * surfaces here so the strategy layer can forward the warning to the AI SDK
+   * call result rather than dropping it silently.
+   */
+  readonly warnings?: SharedV3Warning[];
 }
 
 /**
@@ -105,6 +113,7 @@ interface UserContentItem {
  * @param options.escapeTemplatePlaceholders - Whether to escape Jinja2 template delimiters (default: true).
  * @param options.includeReasoning - Whether to include assistant reasoning parts (default: false).
  * @param options.parsePartProviderOptions - Optional callback to read per-part `providerOptions['sap-ai']`. Strategies opt in to honour part-level directives such as Anthropic `cacheControl`.
+ * @param options.warnings - Optional sink the parser pushes Zod validation issues into.
  * @returns SAP AI SDK ChatMessage array ready for orchestration requests.
  * @throws {UnsupportedFunctionalityError} When encountering unsupported content types or file formats.
  * @throws {InvalidPromptError} When encountering unsupported message roles.
@@ -204,7 +213,10 @@ export function convertToSAPMessages(
         const contentParts: UserContentItem[] = [];
 
         for (const part of message.content) {
-          const partOpts = options.parsePartProviderOptions?.(part.providerOptions);
+          const partOpts = options.parsePartProviderOptions?.(
+            part.providerOptions,
+            options.warnings,
+          );
           const cacheControl = partOpts?.cacheControl;
           switch (part.type) {
             case "file": {

--- a/src/convert-to-sap-messages.ts
+++ b/src/convert-to-sap-messages.ts
@@ -29,6 +29,15 @@ export interface ConvertToSAPMessagesOptions {
    * @default false
    */
   readonly includeReasoning?: boolean;
+  /**
+   * Optional callback that reads per-part `providerOptions['sap-ai']` (e.g. Anthropic
+   * `cacheControl`) and forwards the result onto the SAP message item. Strategies that
+   * do not honour part-level directives (Foundation Models) leave this undefined.
+   * @default undefined
+   */
+  readonly parsePartProviderOptions?: (
+    providerOptions: unknown,
+  ) => undefined | { readonly cacheControl?: { ttl?: "1h" | "5m"; type: "ephemeral" } };
 }
 
 /**
@@ -71,6 +80,7 @@ const JINJA2_DELIMITERS_ESCAPED_PATTERN = new RegExp(`\\{${ZERO_WIDTH_SPACE}([{%
  * @internal
  */
 interface UserContentItem {
+  readonly cache_control?: { ttl?: "1h" | "5m"; type: "ephemeral" };
   readonly file?: {
     readonly file_data: string;
     readonly filename?: string;
@@ -193,6 +203,8 @@ export function convertToSAPMessages(
         const contentParts: UserContentItem[] = [];
 
         for (const part of message.content) {
+          const partOpts = options.parsePartProviderOptions?.(part.providerOptions);
+          const cacheControl = partOpts?.cacheControl;
           switch (part.type) {
             case "file": {
               const fileDataUrl = buildDataUrl(part);
@@ -213,6 +225,7 @@ export function convertToSAPMessages(
                 }
 
                 contentParts.push({
+                  ...(cacheControl ? { cache_control: cacheControl } : {}),
                   image_url: {
                     url: fileDataUrl,
                   },
@@ -220,6 +233,7 @@ export function convertToSAPMessages(
                 });
               } else {
                 contentParts.push({
+                  ...(cacheControl ? { cache_control: cacheControl } : {}),
                   file: {
                     file_data: fileDataUrl,
                     ...(part.filename ? { filename: part.filename } : {}),
@@ -231,6 +245,7 @@ export function convertToSAPMessages(
             }
             case "text": {
               contentParts.push({
+                ...(cacheControl ? { cache_control: cacheControl } : {}),
                 text: maybeEscape(part.text),
                 type: "text",
               });
@@ -246,7 +261,9 @@ export function convertToSAPMessages(
 
         const firstPart = contentParts[0];
         const userMessage: UserChatMessage =
-          contentParts.length === 1 && firstPart?.type === "text"
+          contentParts.length === 1 &&
+          firstPart?.type === "text" &&
+          firstPart.cache_control === undefined
             ? {
                 content: firstPart.text ?? "",
                 role: "user",

--- a/src/convert-to-sap-messages.ts
+++ b/src/convert-to-sap-messages.ts
@@ -155,12 +155,13 @@ export function convertToSAPMessages(
               break;
             }
             case "text": {
+              const escaped = maybeEscape(part.text);
+              if (!escaped) break;
               const partOpts = options.parsePartProviderOptions?.(
                 part.providerOptions,
                 options.warnings,
               );
               const cacheControl = partOpts?.cacheControl;
-              const escaped = maybeEscape(part.text);
               text += escaped;
               textParts.push(cacheControl ? { cacheControl, text: escaped } : { text: escaped });
               if (cacheControl) anyCacheControl = true;

--- a/src/convert-to-sap-messages.ts
+++ b/src/convert-to-sap-messages.ts
@@ -173,12 +173,17 @@ export function convertToSAPMessages(
                 options.warnings,
               );
               if (partOpts?.cacheControl && options.warnings) {
-                options.warnings.push({
-                  details:
-                    "SAP orchestration does not expose cache_control on assistant tool calls.",
-                  feature: "cacheControl on assistant tool-call",
-                  type: "unsupported",
-                });
+                const feature = "cacheControl on assistant tool-call";
+                if (
+                  !options.warnings.some((w) => (w as { feature?: string }).feature === feature)
+                ) {
+                  options.warnings.push({
+                    details:
+                      "SAP orchestration does not expose cache_control on assistant tool calls.",
+                    feature,
+                    type: "unsupported",
+                  });
+                }
               }
               // Normalize tool call input to JSON string (Vercel AI SDK provides strings or objects)
               let argumentsJson: string;

--- a/src/foundation-models-embedding-model-strategy.ts
+++ b/src/foundation-models-embedding-model-strategy.ts
@@ -11,6 +11,7 @@ import type { EmbeddingModelStrategyConfig } from "./sap-ai-strategy.js";
 import type { EmbeddingProviderOptions } from "./strategy-utils.js";
 
 import { BaseEmbeddingModelStrategy } from "./base-embedding-model-strategy.js";
+import { normalizeHeaders } from "./sap-ai-error.js";
 import { buildModelDeployment, hasKeys, normalizeEmbedding } from "./strategy-utils.js";
 
 /**
@@ -73,6 +74,24 @@ export class FoundationModelsEmbeddingModelStrategy extends BaseEmbeddingModelSt
     const embeddingData = response._data.data;
     const sortedEmbeddings = embeddingData.slice().sort((a, b) => a.index - b.index);
     return sortedEmbeddings.map((item) => normalizeEmbedding(item.embedding as number[]));
+  }
+
+  protected override extractRequestId(response: AzureOpenAiEmbeddingResponse): string | undefined {
+    const fn = (response as { getRequestId?: () => string | undefined }).getRequestId;
+    if (typeof fn !== "function") {
+      return undefined;
+    }
+    return fn.call(response);
+  }
+
+  protected override extractResponseHeaders(
+    response: AzureOpenAiEmbeddingResponse,
+  ): Record<string, string> | undefined {
+    try {
+      return normalizeHeaders(response.rawResponse.headers);
+    } catch {
+      return undefined;
+    }
   }
 
   protected extractTokenCount(response: AzureOpenAiEmbeddingResponse): number {

--- a/src/foundation-models-embedding-model-strategy.ts
+++ b/src/foundation-models-embedding-model-strategy.ts
@@ -8,11 +8,15 @@ import type {
 
 import type { SAPAIEmbeddingSettings } from "./sap-ai-settings.js";
 import type { EmbeddingModelStrategyConfig } from "./sap-ai-strategy.js";
-import type { EmbeddingProviderOptions } from "./strategy-utils.js";
+import type { EmbeddingProviderOptions, ResponseMetadata } from "./strategy-utils.js";
 
 import { BaseEmbeddingModelStrategy } from "./base-embedding-model-strategy.js";
-import { normalizeHeaders } from "./sap-ai-error.js";
-import { buildModelDeployment, hasKeys, normalizeEmbedding } from "./strategy-utils.js";
+import {
+  buildModelDeployment,
+  extractResponseMetadata,
+  hasKeys,
+  normalizeEmbedding,
+} from "./strategy-utils.js";
 
 /**
  * Client with pre-merged params for thread-safe concurrent requests.
@@ -76,22 +80,10 @@ export class FoundationModelsEmbeddingModelStrategy extends BaseEmbeddingModelSt
     return sortedEmbeddings.map((item) => normalizeEmbedding(item.embedding as number[]));
   }
 
-  protected override extractRequestId(response: AzureOpenAiEmbeddingResponse): string | undefined {
-    const fn = (response as { getRequestId?: () => string | undefined }).getRequestId;
-    if (typeof fn !== "function") {
-      return undefined;
-    }
-    return fn.call(response);
-  }
-
-  protected override extractResponseHeaders(
+  protected override extractResponseMetadata(
     response: AzureOpenAiEmbeddingResponse,
-  ): Record<string, string> | undefined {
-    try {
-      return normalizeHeaders(response.rawResponse.headers);
-    } catch {
-      return undefined;
-    }
+  ): ResponseMetadata {
+    return extractResponseMetadata(response, "rawResponse");
   }
 
   protected extractTokenCount(response: AzureOpenAiEmbeddingResponse): number {

--- a/src/foundation-models-language-model-strategy.ts
+++ b/src/foundation-models-language-model-strategy.ts
@@ -15,12 +15,12 @@ import {
   type CommonBuildResult,
   type StreamCallResponse,
 } from "./base-language-model-strategy.js";
-import { normalizeHeaders } from "./sap-ai-error.js";
 import {
   buildModelDeployment,
   convertResponseFormat,
   convertToolsToSAPFormat,
   extractCompletionId,
+  extractResponseMetadata,
   type ParamMapping,
   type SAPToolChoice,
   type SDKResponse,
@@ -121,6 +121,7 @@ export class FoundationModelsLanguageModelStrategy extends BaseLanguageModelStra
     const response = await client.run(request, abortSignal ? { signal: abortSignal } : undefined);
 
     const completionId = extractCompletionId(response, ["id"]);
+    const { requestId } = extractResponseMetadata(response, "rawResponse");
 
     return {
       getContent: () => response.getContent(),
@@ -129,6 +130,7 @@ export class FoundationModelsLanguageModelStrategy extends BaseLanguageModelStra
       getToolCalls: () => response.getToolCalls(),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- SAP SDK types headers as any
       rawResponse: { headers: response.rawResponse.headers },
+      requestId,
       responseId: completionId,
     };
   }
@@ -141,19 +143,18 @@ export class FoundationModelsLanguageModelStrategy extends BaseLanguageModelStra
   ): Promise<StreamCallResponse> {
     const streamResponse = await client.stream(request, abortSignal);
 
-    // `rawResponse` is unavailable when the stream was built via the deprecated 0-arg constructor.
-    let responseHeaders: Record<string, string> | undefined;
-    try {
-      responseHeaders = normalizeHeaders(streamResponse.rawResponse.headers);
-    } catch {
-      responseHeaders = undefined;
-    }
+    const { headers: responseHeaders, requestId } = extractResponseMetadata(
+      streamResponse,
+      "rawResponse",
+    );
+    const streamCompletionId = extractCompletionId(streamResponse, ["id"]);
 
     return {
       getFinishReason: () => streamResponse.getFinishReason(),
       getTokenUsage: () => streamResponse.getTokenUsage(),
+      requestId,
       responseHeaders,
-      responseId: streamResponse.getRequestId(),
+      responseId: streamCompletionId,
       stream: streamResponse.stream as AsyncIterable<SDKStreamChunk>,
     };
   }

--- a/src/foundation-models-language-model-strategy.ts
+++ b/src/foundation-models-language-model-strategy.ts
@@ -20,6 +20,7 @@ import {
   buildModelDeployment,
   convertResponseFormat,
   convertToolsToSAPFormat,
+  extractCompletionId,
   type ParamMapping,
   type SAPToolChoice,
   type SDKResponse,
@@ -119,8 +120,7 @@ export class FoundationModelsLanguageModelStrategy extends BaseLanguageModelStra
   ): Promise<SDKResponse> {
     const response = await client.run(request, abortSignal ? { signal: abortSignal } : undefined);
 
-    const completionId =
-      (response as { _data?: { id?: string } })._data?.id ?? response.getRequestId();
+    const completionId = extractCompletionId(response, ["id"]);
 
     return {
       getContent: () => response.getContent(),

--- a/src/foundation-models-language-model-strategy.ts
+++ b/src/foundation-models-language-model-strategy.ts
@@ -19,8 +19,6 @@ import {
   buildModelDeployment,
   convertResponseFormat,
   convertToolsToSAPFormat,
-  extractCompletionId,
-  extractResponseMetadata,
   type ParamMapping,
   type SAPToolChoice,
   type SDKResponse,
@@ -120,8 +118,7 @@ export class FoundationModelsLanguageModelStrategy extends BaseLanguageModelStra
   ): Promise<SDKResponse> {
     const response = await client.run(request, abortSignal ? { signal: abortSignal } : undefined);
 
-    const completionId = extractCompletionId(response, ["id"]);
-    const { requestId } = extractResponseMetadata(response, "rawResponse");
+    const { requestId, responseId } = this.extractMetadata(response);
 
     return {
       getContent: () => response.getContent(),
@@ -131,7 +128,7 @@ export class FoundationModelsLanguageModelStrategy extends BaseLanguageModelStra
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- SAP SDK types headers as any
       rawResponse: { headers: response.rawResponse.headers },
       requestId,
-      responseId: completionId,
+      responseId,
     };
   }
 
@@ -143,20 +140,20 @@ export class FoundationModelsLanguageModelStrategy extends BaseLanguageModelStra
   ): Promise<StreamCallResponse> {
     const streamResponse = await client.stream(request, abortSignal);
 
-    const { headers: responseHeaders, requestId } = extractResponseMetadata(
-      streamResponse,
-      "rawResponse",
-    );
-    const streamCompletionId = extractCompletionId(streamResponse, ["id"]);
+    const { requestId, responseHeaders, responseId } = this.extractMetadata(streamResponse);
 
     return {
       getFinishReason: () => streamResponse.getFinishReason(),
       getTokenUsage: () => streamResponse.getTokenUsage(),
       requestId,
       responseHeaders,
-      responseId: streamCompletionId,
+      responseId,
       stream: streamResponse.stream as AsyncIterable<SDKStreamChunk>,
     };
+  }
+
+  protected getCompletionIdPath(): readonly string[] {
+    return ["id"];
   }
 
   protected getParamMappings(): readonly ParamMapping[] {

--- a/src/foundation-models-language-model-strategy.ts
+++ b/src/foundation-models-language-model-strategy.ts
@@ -119,12 +119,8 @@ export class FoundationModelsLanguageModelStrategy extends BaseLanguageModelStra
   ): Promise<SDKResponse> {
     const response = await client.run(request, abortSignal ? { signal: abortSignal } : undefined);
 
-    const headers = normalizeHeaders(response.rawResponse.headers);
-
-    // Extract completion ID from SDK internal data (chatcmpl-xxx style).
-    // Falls back to the x-request-id header if not available.
     const completionId =
-      (response as { _data?: { id?: string } })._data?.id ?? headers?.["x-request-id"];
+      (response as { _data?: { id?: string } })._data?.id ?? response.getRequestId();
 
     return {
       getContent: () => response.getContent(),
@@ -145,11 +141,19 @@ export class FoundationModelsLanguageModelStrategy extends BaseLanguageModelStra
   ): Promise<StreamCallResponse> {
     const streamResponse = await client.stream(request, abortSignal);
 
-    // AzureOpenAiChatCompletionStreamResponse exposes neither rawResponse nor _data.
-    // Response headers and completion ID are unavailable — base strategy falls back to UUID.
+    // `rawResponse` is unavailable when the stream was built via the deprecated 0-arg constructor.
+    let responseHeaders: Record<string, string> | undefined;
+    try {
+      responseHeaders = normalizeHeaders(streamResponse.rawResponse.headers);
+    } catch {
+      responseHeaders = undefined;
+    }
+
     return {
       getFinishReason: () => streamResponse.getFinishReason(),
       getTokenUsage: () => streamResponse.getTokenUsage(),
+      responseHeaders,
+      responseId: streamResponse.getRequestId(),
       stream: streamResponse.stream as AsyncIterable<SDKStreamChunk>,
     };
   }

--- a/src/foundation-models-language-model-strategy.ts
+++ b/src/foundation-models-language-model-strategy.ts
@@ -88,7 +88,7 @@ export class FoundationModelsLanguageModelStrategy extends BaseLanguageModelStra
 
     const request: AzureOpenAiChatCompletionParameters = {
       messages: commonParts.messages as AzureOpenAiChatCompletionParameters["messages"],
-      ...commonParts.modelParams,
+      ...(commonParts.modelParams as Partial<AzureOpenAiChatCompletionParameters>),
       ...(toolsResult.tools?.length ? { tools: toolsResult.tools } : {}),
       ...(toolChoice ? { tool_choice: toolChoice } : {}),
       ...(responseFormat ? { response_format: responseFormat } : {}),

--- a/src/orchestration-embedding-model-strategy.ts
+++ b/src/orchestration-embedding-model-strategy.ts
@@ -11,8 +11,13 @@ import type { SAPAIEmbeddingSettings } from "./sap-ai-settings.js";
 import type { EmbeddingModelStrategyConfig } from "./sap-ai-strategy.js";
 
 import { BaseEmbeddingModelStrategy } from "./base-embedding-model-strategy.js";
-import { normalizeHeaders } from "./sap-ai-error.js";
-import { type EmbeddingProviderOptions, hasKeys, normalizeEmbedding } from "./strategy-utils.js";
+import {
+  type EmbeddingProviderOptions,
+  extractResponseMetadata,
+  hasKeys,
+  normalizeEmbedding,
+  type ResponseMetadata,
+} from "./strategy-utils.js";
 
 /** @internal */
 type OrchestrationEmbeddingClientClass = typeof OrchestrationEmbeddingClient;
@@ -79,24 +84,10 @@ export class OrchestrationEmbeddingModelStrategy extends BaseEmbeddingModelStrat
     return sortedEmbeddings.map((data) => normalizeEmbedding(data.embedding));
   }
 
-  protected override extractRequestId(
+  protected override extractResponseMetadata(
     response: OrchestrationEmbeddingResponse,
-  ): string | undefined {
-    const fn = (response as { getRequestId?: () => string | undefined }).getRequestId;
-    if (typeof fn !== "function") {
-      return undefined;
-    }
-    return fn.call(response);
-  }
-
-  protected override extractResponseHeaders(
-    response: OrchestrationEmbeddingResponse,
-  ): Record<string, string> | undefined {
-    try {
-      return normalizeHeaders(response.response.headers);
-    } catch {
-      return undefined;
-    }
+  ): ResponseMetadata {
+    return extractResponseMetadata(response, "response");
   }
 
   protected extractTokenCount(response: OrchestrationEmbeddingResponse): number {

--- a/src/orchestration-embedding-model-strategy.ts
+++ b/src/orchestration-embedding-model-strategy.ts
@@ -1,5 +1,5 @@
 /** Orchestration embedding model strategy using `@sap-ai-sdk/orchestration`. */
-import type { EmbeddingModelV3Embedding } from "@ai-sdk/provider";
+import type { EmbeddingModelV3Embedding, SharedV3Warning } from "@ai-sdk/provider";
 import type {
   EmbeddingModelConfig,
   EmbeddingModuleConfig,
@@ -12,6 +12,7 @@ import type { SAPAIEmbeddingSettings } from "./sap-ai-settings.js";
 import type { EmbeddingModelStrategyConfig } from "./sap-ai-strategy.js";
 
 import { BaseEmbeddingModelStrategy } from "./base-embedding-model-strategy.js";
+import { validateMaskingProvidersDeprecation } from "./sap-ai-validation.js";
 import {
   type EmbeddingProviderOptions,
   extractResponseMetadata,
@@ -100,5 +101,12 @@ export class OrchestrationEmbeddingModelStrategy extends BaseEmbeddingModelStrat
 
   protected getUrl(): string {
     return "sap-ai:orchestration/embeddings";
+  }
+
+  protected override resolveWarnings(
+    settings: SAPAIEmbeddingSettings,
+    warnings: SharedV3Warning[],
+  ): void {
+    validateMaskingProvidersDeprecation(settings, warnings);
   }
 }

--- a/src/orchestration-embedding-model-strategy.ts
+++ b/src/orchestration-embedding-model-strategy.ts
@@ -11,6 +11,7 @@ import type { SAPAIEmbeddingSettings } from "./sap-ai-settings.js";
 import type { EmbeddingModelStrategyConfig } from "./sap-ai-strategy.js";
 
 import { BaseEmbeddingModelStrategy } from "./base-embedding-model-strategy.js";
+import { normalizeHeaders } from "./sap-ai-error.js";
 import { type EmbeddingProviderOptions, hasKeys, normalizeEmbedding } from "./strategy-utils.js";
 
 /** @internal */
@@ -76,6 +77,26 @@ export class OrchestrationEmbeddingModelStrategy extends BaseEmbeddingModelStrat
     const embeddingData = response.getEmbeddings();
     const sortedEmbeddings = [...embeddingData].sort((a, b) => a.index - b.index);
     return sortedEmbeddings.map((data) => normalizeEmbedding(data.embedding));
+  }
+
+  protected override extractRequestId(
+    response: OrchestrationEmbeddingResponse,
+  ): string | undefined {
+    const fn = (response as { getRequestId?: () => string | undefined }).getRequestId;
+    if (typeof fn !== "function") {
+      return undefined;
+    }
+    return fn.call(response);
+  }
+
+  protected override extractResponseHeaders(
+    response: OrchestrationEmbeddingResponse,
+  ): Record<string, string> | undefined {
+    try {
+      return normalizeHeaders(response.response.headers);
+    } catch {
+      return undefined;
+    }
   }
 
   protected extractTokenCount(response: OrchestrationEmbeddingResponse): number {

--- a/src/orchestration-embedding-model-strategy.ts
+++ b/src/orchestration-embedding-model-strategy.ts
@@ -3,6 +3,7 @@ import type { EmbeddingModelV3Embedding } from "@ai-sdk/provider";
 import type {
   EmbeddingModelConfig,
   EmbeddingModuleConfig,
+  MaskingModule,
   OrchestrationEmbeddingClient,
   OrchestrationEmbeddingResponse,
 } from "@sap-ai-sdk/orchestration";
@@ -58,7 +59,9 @@ export class OrchestrationEmbeddingModelStrategy extends BaseEmbeddingModelStrat
 
     const moduleConfig: EmbeddingModuleConfig = {
       embeddings: embeddingConfig,
-      ...(settings.masking && hasKeys(settings.masking) ? { masking: settings.masking } : {}),
+      ...(settings.masking && hasKeys(settings.masking)
+        ? { masking: settings.masking as MaskingModule }
+        : {}),
     };
 
     return new this.ClientClass(moduleConfig, config.deploymentConfig, config.destination);

--- a/src/orchestration-language-model-strategy.ts
+++ b/src/orchestration-language-model-strategy.ts
@@ -847,11 +847,10 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
     }
 
     if (optionsTools && optionsTools.length > 0) {
-      const result = convertToolsToSAPFormat<ChatCompletionTool>(
-        optionsTools,
-        parseSAPPartProviderOptions,
+      const result = convertToolsToSAPFormat<ChatCompletionTool>(optionsTools, {
+        parser: parseSAPPartProviderOptions,
         warnings,
-      );
+      });
       warnings.push(...result.warnings);
       return result.tools;
     }

--- a/src/orchestration-language-model-strategy.ts
+++ b/src/orchestration-language-model-strategy.ts
@@ -30,6 +30,7 @@ import { normalizeHeaders } from "./sap-ai-error.js";
 import {
   getProviderName,
   orchestrationConfigRefSchema,
+  parseSAPPartProviderOptions,
   sapAILanguageModelProviderOptions,
 } from "./sap-ai-provider-options.js";
 import {
@@ -256,6 +257,7 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
     const messages = convertToSAPMessages(options.prompt, {
       escapeTemplatePlaceholders: this.getEscapeTemplatePlaceholders(sapOptions, settings),
       includeReasoning: this.getIncludeReasoning(sapOptions, settings),
+      parsePartProviderOptions: this.getPartProviderOptionsParser(),
     });
 
     // In configRef mode, modelParams from settings/options are ignored (server-side config)
@@ -452,6 +454,14 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
 
   protected getParamMappings(): readonly ParamMapping[] {
     return ORCHESTRATION_PARAM_MAPPINGS;
+  }
+
+  protected override getPartProviderOptionsParser():
+    | ((
+        providerOptions: unknown,
+      ) => undefined | { readonly cacheControl?: { ttl?: "1h" | "5m"; type: "ephemeral" } })
+    | undefined {
+    return parseSAPPartProviderOptions;
   }
 
   protected getUrl(): string {

--- a/src/orchestration-language-model-strategy.ts
+++ b/src/orchestration-language-model-strategy.ts
@@ -852,7 +852,10 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
     }
 
     if (optionsTools && optionsTools.length > 0) {
-      const result = convertToolsToSAPFormat<ChatCompletionTool>(optionsTools);
+      const result = convertToolsToSAPFormat<ChatCompletionTool>(
+        optionsTools,
+        parseSAPPartProviderOptions,
+      );
       warnings.push(...result.warnings);
       return result.tools;
     }

--- a/src/orchestration-language-model-strategy.ts
+++ b/src/orchestration-language-model-strategy.ts
@@ -34,6 +34,7 @@ import {
   parseSAPPartProviderOptions,
   sapAILanguageModelProviderOptions,
 } from "./sap-ai-provider-options.js";
+import { pushDeprecatedMaskingProvidersWarning } from "./sap-ai-validation.js";
 import {
   buildModelParams,
   convertResponseFormat,
@@ -255,6 +256,8 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
     const promptTemplateRef = this.resolvePromptTemplateRef(sapOptions, settings);
 
     const warnings: SharedV3Warning[] = [];
+
+    pushDeprecatedMaskingProvidersWarning(settings, warnings);
 
     const messages = convertToSAPMessages(options.prompt, {
       escapeTemplatePlaceholders: this.getEscapeTemplatePlaceholders(sapOptions, settings),

--- a/src/orchestration-language-model-strategy.ts
+++ b/src/orchestration-language-model-strategy.ts
@@ -12,6 +12,7 @@ import type {
 
 import { parseProviderOptions } from "@ai-sdk/provider-utils";
 
+import type { ParsePartProviderOptions } from "./sap-ai-provider-options.js";
 import type {
   OrchestrationModelSettings,
   PromptTemplateRef,
@@ -456,11 +457,7 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
     return ORCHESTRATION_PARAM_MAPPINGS;
   }
 
-  protected override getPartProviderOptionsParser():
-    | ((
-        providerOptions: unknown,
-      ) => undefined | { readonly cacheControl?: { ttl?: "1h" | "5m"; type: "ephemeral" } })
-    | undefined {
+  protected override getPartProviderOptionsParser(): ParsePartProviderOptions | undefined {
     return parseSAPPartProviderOptions;
   }
 

--- a/src/orchestration-language-model-strategy.ts
+++ b/src/orchestration-language-model-strategy.ts
@@ -34,7 +34,7 @@ import {
   parseSAPPartProviderOptions,
   sapAILanguageModelProviderOptions,
 } from "./sap-ai-provider-options.js";
-import { pushDeprecatedMaskingProvidersWarning } from "./sap-ai-validation.js";
+import { validateMaskingProvidersDeprecation } from "./sap-ai-validation.js";
 import {
   buildModelParams,
   convertResponseFormat,
@@ -257,7 +257,7 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
 
     const warnings: SharedV3Warning[] = [];
 
-    pushDeprecatedMaskingProvidersWarning(settings, warnings);
+    validateMaskingProvidersDeprecation(settings, warnings);
 
     const messages = convertToSAPMessages(options.prompt, {
       escapeTemplatePlaceholders: this.getEscapeTemplatePlaceholders(sapOptions, settings),

--- a/src/orchestration-language-model-strategy.ts
+++ b/src/orchestration-language-model-strategy.ts
@@ -259,6 +259,7 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
       escapeTemplatePlaceholders: this.getEscapeTemplatePlaceholders(sapOptions, settings),
       includeReasoning: this.getIncludeReasoning(sapOptions, settings),
       parsePartProviderOptions: this.getPartProviderOptionsParser(),
+      warnings,
     });
 
     // In configRef mode, modelParams from settings/options are ignored (server-side config)
@@ -855,6 +856,7 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
       const result = convertToolsToSAPFormat<ChatCompletionTool>(
         optionsTools,
         parseSAPPartProviderOptions,
+        warnings,
       );
       warnings.push(...result.warnings);
       return result.tools;

--- a/src/orchestration-language-model-strategy.ts
+++ b/src/orchestration-language-model-strategy.ts
@@ -40,6 +40,7 @@ import {
   convertResponseFormat,
   convertToolsToSAPFormat,
   extractCompletionId,
+  extractResponseMetadata,
   hasKeys,
   mapToolChoice,
   type ParamMapping,
@@ -396,6 +397,7 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
     );
 
     const completionId = extractCompletionId(response, ["final_result", "id"]);
+    const { requestId } = extractResponseMetadata(response, "rawResponse");
 
     return {
       getCitations: () =>
@@ -410,6 +412,7 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
       getToolCalls: () => response.getToolCalls(),
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- SAP SDK types headers as any
       rawResponse: { headers: response.rawResponse.headers },
+      requestId,
       responseId: completionId,
     };
   }
@@ -424,6 +427,7 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
     const streamResponse = await client.stream(request, abortSignal, sdkStreamOptions);
 
     const streamCompletionId = extractCompletionId(streamResponse, ["final_result", "id"]);
+    const { requestId } = extractResponseMetadata(streamResponse, "rawResponse");
 
     return {
       getCitations: () =>
@@ -434,6 +438,7 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
           streamResponse as { getIntermediateFailures?: () => undefined | unknown[] }
         ).getIntermediateFailures?.(),
       getTokenUsage: () => streamResponse.getTokenUsage(),
+      requestId,
       responseHeaders: normalizeHeaders(streamResponse.rawResponse.headers),
       responseId: streamCompletionId,
       stream: streamResponse.stream as AsyncIterable<SDKStreamChunk>,

--- a/src/orchestration-language-model-strategy.ts
+++ b/src/orchestration-language-model-strategy.ts
@@ -3,7 +3,6 @@ import type { LanguageModelV3CallOptions, SharedV3Warning } from "@ai-sdk/provid
 import type {
   ChatCompletionTool,
   ChatMessage,
-  LlmModelParams,
   OrchestrationClient,
   OrchestrationConfigRef,
   OrchestrationModuleConfig,
@@ -71,17 +70,6 @@ interface OrchestrationResolvedState {
   readonly promptTemplateRef: PromptTemplateRef | undefined;
   readonly tools: ChatCompletionTool[] | undefined;
 }
-
-/**
- * SAP model parameters with orchestration-specific fields.
- * @internal
- */
-type SAPModelParams = LlmModelParams & {
-  parallel_tool_calls?: boolean;
-  seed?: number;
-  stop?: string[];
-  top_k?: number;
-};
 
 /**
  * Builds the template_ref object from a PromptTemplateRef.
@@ -495,7 +483,7 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
     config: LanguageModelStrategyConfig,
     settings: OrchestrationModelSettings,
     params: {
-      readonly modelParams: SAPModelParams;
+      readonly modelParams: Record<string, unknown>;
       readonly promptTemplateRef?: PromptTemplateRef;
       readonly responseFormat?: unknown;
       readonly toolChoice?: SAPToolChoice;

--- a/src/orchestration-language-model-strategy.ts
+++ b/src/orchestration-language-model-strategy.ts
@@ -38,6 +38,7 @@ import {
   buildModelParams,
   convertResponseFormat,
   convertToolsToSAPFormat,
+  extractCompletionId,
   hasKeys,
   mapToolChoice,
   type ParamMapping,
@@ -391,11 +392,7 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
       abortSignal ? { signal: abortSignal } : undefined,
     );
 
-    // Extract completion ID from SDK internal data (chatcmpl-xxx style).
-    // Falls back to the pipeline request ID if not available.
-    const completionId =
-      (response as { _data?: { final_result?: { id?: string } } })._data?.final_result?.id ??
-      response.getRequestId();
+    const completionId = extractCompletionId(response, ["final_result", "id"]);
 
     return {
       getCitations: () =>
@@ -423,10 +420,7 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
     const sdkStreamOptions = this.buildSdkStreamOptions(settings.streamOptions);
     const streamResponse = await client.stream(request, abortSignal, sdkStreamOptions);
 
-    // _data starts as {} and is populated during stream consumption;
-    // final_result.id is undefined before the stream is consumed.
-    const streamCompletionId = (streamResponse as { _data?: { final_result?: { id?: string } } })
-      ._data?.final_result?.id;
+    const streamCompletionId = extractCompletionId(streamResponse, ["final_result", "id"]);
 
     return {
       getCitations: () =>

--- a/src/orchestration-language-model-strategy.ts
+++ b/src/orchestration-language-model-strategy.ts
@@ -10,8 +10,6 @@ import type {
   OrchestrationModuleConfigList,
 } from "@sap-ai-sdk/orchestration";
 
-import { parseProviderOptions } from "@ai-sdk/provider-utils";
-
 import type { ParsePartProviderOptions } from "./sap-ai-provider-options.js";
 import type {
   OrchestrationModelSettings,
@@ -25,21 +23,16 @@ import {
   type CommonBuildResult,
   type StreamCallResponse,
 } from "./base-language-model-strategy.js";
-import { convertToSAPMessages } from "./convert-to-sap-messages.js";
 import { deepMerge } from "./deep-merge.js";
 import {
-  getProviderName,
   orchestrationConfigRefSchema,
   parseSAPPartProviderOptions,
-  sapAILanguageModelProviderOptions,
 } from "./sap-ai-provider-options.js";
 import { validateMaskingProvidersDeprecation } from "./sap-ai-validation.js";
 import {
-  buildModelParams,
   convertResponseFormat,
   convertToolsToSAPFormat,
   hasKeys,
-  mapToolChoice,
   type ParamMapping,
   type SAPToolChoice,
   type SDKCitation,
@@ -226,76 +219,6 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
     this.ClientClass = ClientClass;
   }
 
-  /**
-   * Builds common parts with orchestration-specific configRef resolution.
-   *
-   * Resolves configRef once and stores it in sapOptions for use by
-   * createClient and buildRequest, avoiding duplicate resolution.
-   * @param config - Strategy configuration.
-   * @param settings - Model settings.
-   * @param options - AI SDK call options.
-   * @returns Common build result with resolved configRef in sapOptions.
-   * @internal
-   */
-  protected override async buildCommonParts(
-    config: LanguageModelStrategyConfig,
-    settings: OrchestrationModelSettings,
-    options: LanguageModelV3CallOptions,
-  ): Promise<CommonBuildResult<ChatMessage[], SAPToolChoice | undefined>> {
-    const providerName = getProviderName(config.provider);
-
-    const sapOptions = await parseProviderOptions({
-      provider: providerName,
-      providerOptions: options.providerOptions,
-      schema: sapAILanguageModelProviderOptions,
-    });
-
-    const configRef = this.resolveConfigRef(sapOptions, settings);
-    const promptTemplateRef = this.resolvePromptTemplateRef(sapOptions, settings);
-    const usingServerResolvedMasking = configRef !== undefined;
-
-    const warnings: SharedV3Warning[] = [];
-
-    if (!usingServerResolvedMasking) {
-      validateMaskingProvidersDeprecation(settings, warnings);
-    }
-
-    const messages = convertToSAPMessages(options.prompt, {
-      escapeTemplatePlaceholders: this.getEscapeTemplatePlaceholders(sapOptions, settings),
-      includeReasoning: this.getIncludeReasoning(sapOptions, settings),
-      parsePartProviderOptions: this.getPartProviderOptionsParser(),
-      warnings,
-    });
-
-    // In configRef mode, modelParams from settings/options are ignored (server-side config)
-    // But we still build them to generate warnings for ignored settings
-    const { modelParams, warnings: paramWarnings } = buildModelParams({
-      options,
-      paramMappings: this.getParamMappings(),
-      providerModelParams: sapOptions?.modelParams,
-      settingsModelParams: settings.modelParams,
-    });
-    warnings.push(...paramWarnings);
-
-    const toolChoice = mapToolChoice(options.toolChoice);
-
-    const tools = this.resolveTools(settings, options, warnings);
-
-    return {
-      messages,
-      modelParams,
-      providerName,
-      resolvedState: {
-        configRef,
-        promptTemplateRef,
-        tools,
-      } satisfies OrchestrationResolvedState,
-      sapOptions,
-      toolChoice,
-      warnings,
-    };
-  }
-
   protected buildRequest(
     config: LanguageModelStrategyConfig,
     settings: OrchestrationModelSettings,
@@ -468,6 +391,38 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
 
   protected getUrl(): string {
     return "sap-ai:orchestration";
+  }
+
+  /**
+   * Resolves orchestration-specific extra state: `configRef`, `promptTemplateRef`,
+   * and `tools`. Pushes the masking-providers deprecation warning when masking
+   * is locally configured (skipped under `configRef` because the server-side
+   * configuration overrides it).
+   * @param _config - Strategy configuration (unused).
+   * @param settings - Model settings.
+   * @param sapOptions - Parsed provider options.
+   * @param options - AI SDK call options.
+   * @param warnings - Shared warnings sink.
+   * @returns Resolved orchestration state.
+   * @internal
+   */
+  protected override resolveAdditionalState(
+    _config: LanguageModelStrategyConfig,
+    settings: OrchestrationModelSettings,
+    sapOptions: Record<string, unknown> | undefined,
+    options: LanguageModelV3CallOptions,
+    warnings: SharedV3Warning[],
+  ): OrchestrationResolvedState {
+    const configRef = this.resolveConfigRef(sapOptions, settings);
+    const promptTemplateRef = this.resolvePromptTemplateRef(sapOptions, settings);
+
+    if (configRef === undefined) {
+      validateMaskingProvidersDeprecation(settings, warnings);
+    }
+
+    const tools = this.resolveTools(settings, options, warnings);
+
+    return { configRef, promptTemplateRef, tools };
   }
 
   /**

--- a/src/orchestration-language-model-strategy.ts
+++ b/src/orchestration-language-model-strategy.ts
@@ -255,10 +255,13 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
 
     const configRef = this.resolveConfigRef(sapOptions, settings);
     const promptTemplateRef = this.resolvePromptTemplateRef(sapOptions, settings);
+    const usingServerResolvedMasking = configRef !== undefined;
 
     const warnings: SharedV3Warning[] = [];
 
-    validateMaskingProvidersDeprecation(settings, warnings);
+    if (!usingServerResolvedMasking) {
+      validateMaskingProvidersDeprecation(settings, warnings);
+    }
 
     const messages = convertToSAPMessages(options.prompt, {
       escapeTemplatePlaceholders: this.getEscapeTemplatePlaceholders(sapOptions, settings),

--- a/src/orchestration-language-model-strategy.ts
+++ b/src/orchestration-language-model-strategy.ts
@@ -27,7 +27,6 @@ import {
 } from "./base-language-model-strategy.js";
 import { convertToSAPMessages } from "./convert-to-sap-messages.js";
 import { deepMerge } from "./deep-merge.js";
-import { normalizeHeaders } from "./sap-ai-error.js";
 import {
   getProviderName,
   orchestrationConfigRefSchema,
@@ -39,8 +38,6 @@ import {
   buildModelParams,
   convertResponseFormat,
   convertToolsToSAPFormat,
-  extractCompletionId,
-  extractResponseMetadata,
   hasKeys,
   mapToolChoice,
   type ParamMapping,
@@ -399,8 +396,7 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
       abortSignal ? { signal: abortSignal } : undefined,
     );
 
-    const completionId = extractCompletionId(response, ["final_result", "id"]);
-    const { requestId } = extractResponseMetadata(response, "rawResponse");
+    const { requestId, responseId } = this.extractMetadata(response);
 
     return {
       getCitations: () =>
@@ -416,7 +412,7 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment -- SAP SDK types headers as any
       rawResponse: { headers: response.rawResponse.headers },
       requestId,
-      responseId: completionId,
+      responseId,
     };
   }
 
@@ -429,8 +425,7 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
     const sdkStreamOptions = this.buildSdkStreamOptions(settings.streamOptions);
     const streamResponse = await client.stream(request, abortSignal, sdkStreamOptions);
 
-    const streamCompletionId = extractCompletionId(streamResponse, ["final_result", "id"]);
-    const { requestId } = extractResponseMetadata(streamResponse, "rawResponse");
+    const { requestId, responseHeaders, responseId } = this.extractMetadata(streamResponse);
 
     return {
       getCitations: () =>
@@ -442,10 +437,14 @@ export class OrchestrationLanguageModelStrategy extends BaseLanguageModelStrateg
         ).getIntermediateFailures?.(),
       getTokenUsage: () => streamResponse.getTokenUsage(),
       requestId,
-      responseHeaders: normalizeHeaders(streamResponse.rawResponse.headers),
-      responseId: streamCompletionId,
+      responseHeaders,
+      responseId,
       stream: streamResponse.stream as AsyncIterable<SDKStreamChunk>,
     };
+  }
+
+  protected getCompletionIdPath(): readonly string[] {
+    return ["final_result", "id"];
   }
 
   protected getEscapeTemplatePlaceholders(

--- a/src/sap-ai-adapters-v3-to-v2.test.ts
+++ b/src/sap-ai-adapters-v3-to-v2.test.ts
@@ -218,7 +218,7 @@ describe("convertUsageToV2", () => {
     });
   });
 
-  it("should drop usage.raw silently at the V3\u2192V2 boundary", () => {
+  it("should drop usage.raw silently at the V3→V2 boundary", () => {
     const internalUsage = {
       inputTokens: { cacheRead: undefined, cacheWrite: undefined, noCache: 10, total: 10 },
       outputTokens: { reasoning: undefined, text: 20, total: 20 },

--- a/src/sap-ai-adapters-v3-to-v2.test.ts
+++ b/src/sap-ai-adapters-v3-to-v2.test.ts
@@ -217,6 +217,28 @@ describe("convertUsageToV2", () => {
       totalTokens: 18000,
     });
   });
+
+  it("should drop usage.raw silently at the V3\u2192V2 boundary", () => {
+    const internalUsage = {
+      inputTokens: { cacheRead: undefined, cacheWrite: undefined, noCache: 10, total: 10 },
+      outputTokens: { reasoning: undefined, text: 20, total: 20 },
+      raw: {
+        accepted_prediction_tokens: 1,
+        prompt_tokens_details: { audio_tokens: 5 },
+      },
+    } as InternalUsage & { raw: Record<string, unknown> };
+
+    const v2Usage = convertUsageToV2(internalUsage);
+
+    expect(v2Usage).not.toHaveProperty("raw");
+    expect(v2Usage).toEqual({
+      cachedInputTokens: undefined,
+      inputTokens: 10,
+      outputTokens: 20,
+      reasoningTokens: undefined,
+      totalTokens: 30,
+    });
+  });
 });
 
 describe("convertWarningToV2", () => {

--- a/src/sap-ai-embedding-model-v2.test.ts
+++ b/src/sap-ai-embedding-model-v2.test.ts
@@ -63,7 +63,7 @@ describe("SAPAIEmbeddingModelV2", () => {
       expect(result.response?.body).toEqual({ data: "test" });
     });
 
-    it("should preserve providerMetadata['sap-ai'].requestId across the V3→V2 cast", async () => {
+    it("should preserve providerMetadata['sap-ai'].requestId through the V3→V2 facade", async () => {
       const model = new SAPAIEmbeddingModelV2("text-embedding-ada-002", {}, defaultConfig);
 
       const mockDoEmbed = vi.fn().mockResolvedValue({

--- a/src/sap-ai-embedding-model-v2.test.ts
+++ b/src/sap-ai-embedding-model-v2.test.ts
@@ -63,6 +63,34 @@ describe("SAPAIEmbeddingModelV2", () => {
       expect(result.response?.body).toEqual({ data: "test" });
     });
 
+    it("should preserve providerMetadata['sap-ai'].requestId across the V3→V2 cast", async () => {
+      const model = new SAPAIEmbeddingModelV2("text-embedding-ada-002", {}, defaultConfig);
+
+      const mockDoEmbed = vi.fn().mockResolvedValue({
+        embeddings: [[0.1, 0.2]],
+        providerMetadata: {
+          "sap-ai": {
+            model: "text-embedding-ada-002",
+            requestId: "v3-to-v2-req-id",
+            version: "test",
+          },
+        },
+        response: { headers: { "x-request-id": "v3-to-v2-req-id" } },
+        usage: { tokens: 1 },
+        warnings: [],
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      (model as any).internalModel.doEmbed = mockDoEmbed;
+
+      const result = await model.doEmbed({ values: ["Test"] });
+
+      expect(
+        (result.providerMetadata?.["sap-ai"] as undefined | { requestId?: string })?.requestId,
+      ).toBe("v3-to-v2-req-id");
+      expect(result.response?.headers?.["x-request-id"]).toBe("v3-to-v2-req-id");
+    });
+
     it("should forward all options to internal model (abortSignal, headers, providerOptions)", async () => {
       const model = new SAPAIEmbeddingModelV2("text-embedding-ada-002", {}, defaultConfig);
 

--- a/src/sap-ai-embedding-model-v2.test.ts
+++ b/src/sap-ai-embedding-model-v2.test.ts
@@ -168,44 +168,46 @@ describe("SAPAIEmbeddingModelV2", () => {
       },
     ])("should log $description to console", async ({ expectedMessage, warnings }) => {
       const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+      try {
+        const model = new SAPAIEmbeddingModelV2("text-embedding-ada-002", {}, defaultConfig);
 
-      const model = new SAPAIEmbeddingModelV2("text-embedding-ada-002", {}, defaultConfig);
+        const mockDoEmbed = vi.fn().mockResolvedValue({
+          embeddings: [[0.1, 0.2, 0.3]],
+          usage: { tokens: 5 },
+          warnings,
+        });
 
-      const mockDoEmbed = vi.fn().mockResolvedValue({
-        embeddings: [[0.1, 0.2, 0.3]],
-        usage: { tokens: 5 },
-        warnings,
-      });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+        (model as any).internalModel.doEmbed = mockDoEmbed;
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-      (model as any).internalModel.doEmbed = mockDoEmbed;
+        await model.doEmbed({ values: ["Test"] });
 
-      await model.doEmbed({ values: ["Test"] });
-
-      expect(consoleWarnSpy).toHaveBeenCalledWith(expectedMessage);
-
-      consoleWarnSpy.mockRestore();
+        expect(consoleWarnSpy).toHaveBeenCalledWith(expectedMessage);
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
     });
 
     it("should not log when warnings array is empty", async () => {
       const consoleWarnSpy = vi.spyOn(console, "warn").mockImplementation(vi.fn());
+      try {
+        const model = new SAPAIEmbeddingModelV2("text-embedding-ada-002", {}, defaultConfig);
 
-      const model = new SAPAIEmbeddingModelV2("text-embedding-ada-002", {}, defaultConfig);
+        const mockDoEmbed = vi.fn().mockResolvedValue({
+          embeddings: [[0.1, 0.2, 0.3]],
+          usage: { tokens: 5 },
+          warnings: [],
+        });
 
-      const mockDoEmbed = vi.fn().mockResolvedValue({
-        embeddings: [[0.1, 0.2, 0.3]],
-        usage: { tokens: 5 },
-        warnings: [],
-      });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+        (model as any).internalModel.doEmbed = mockDoEmbed;
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-      (model as any).internalModel.doEmbed = mockDoEmbed;
+        await model.doEmbed({ values: ["Test"] });
 
-      await model.doEmbed({ values: ["Test"] });
-
-      expect(consoleWarnSpy).not.toHaveBeenCalled();
-
-      consoleWarnSpy.mockRestore();
+        expect(consoleWarnSpy).not.toHaveBeenCalled();
+      } finally {
+        consoleWarnSpy.mockRestore();
+      }
     });
   });
 });

--- a/src/sap-ai-embedding-model-v2.ts
+++ b/src/sap-ai-embedding-model-v2.ts
@@ -10,7 +10,6 @@
 import type {
   EmbeddingModelV2,
   EmbeddingModelV3CallOptions as InternalCallOptions,
-  SharedV3ProviderMetadata as InternalProviderMetadata,
   SharedV2Headers,
   SharedV2ProviderMetadata,
   SharedV2ProviderOptions,
@@ -20,7 +19,7 @@ import type { HttpDestinationOrFetchOptions } from "@sap-cloud-sdk/connectivity"
 
 import type { SAPAIApiType, SAPAIEmbeddingSettings } from "./sap-ai-settings.js";
 
-import { convertWarningsToV2 } from "./sap-ai-adapters-v3-to-v2.js";
+import { convertProviderMetadataToV2, convertWarningsToV2 } from "./sap-ai-adapters-v3-to-v2.js";
 import { SAPAIEmbeddingModel } from "./sap-ai-embedding-model.js";
 
 /** @internal */
@@ -135,7 +134,7 @@ export class SAPAIEmbeddingModelV2 implements EmbeddingModelV2<string> {
     // Return result in V2 format
     return {
       embeddings: result.embeddings,
-      providerMetadata: castProviderMetadataToV2(result.providerMetadata),
+      providerMetadata: convertProviderMetadataToV2(result.providerMetadata),
       response: result.response
         ? {
             body: result.response.body,
@@ -145,17 +144,4 @@ export class SAPAIEmbeddingModelV2 implements EmbeddingModelV2<string> {
       usage: result.usage,
     };
   }
-}
-
-/**
- * Casts internal provider metadata to V2 format.
- * @param metadata - Internal provider metadata.
- * @returns V2 provider metadata.
- * @internal
- */
-function castProviderMetadataToV2(
-  metadata: InternalProviderMetadata | undefined,
-): SharedV2ProviderMetadata | undefined {
-  // Safe cast - SAP implementation uses conditional spreads to avoid undefined values
-  return metadata as SharedV2ProviderMetadata | undefined;
 }

--- a/src/sap-ai-embedding-model.test.ts
+++ b/src/sap-ai-embedding-model.test.ts
@@ -29,6 +29,8 @@ interface FMEmbeddingResponse {
     data: { embedding: number[] | string; index: number }[];
     usage: { prompt_tokens: number; total_tokens: number };
   };
+  getRequestId?: () => string | undefined;
+  rawResponse?: { headers: Record<string, unknown> };
 }
 
 interface OrchestrationConstructorCall {
@@ -45,7 +47,9 @@ interface OrchestrationEmbedCall {
 }
 interface OrchestrationEmbeddingResponse {
   getEmbeddings: () => { embedding: number[] | string; index: number; object: string }[];
+  getRequestId?: () => string | undefined;
   getTokenUsage: () => { prompt_tokens: number; total_tokens: number };
+  response?: { headers: Record<string, unknown> };
 }
 
 vi.mock("@sap-ai-sdk/orchestration", () => {
@@ -68,14 +72,20 @@ vi.mock("@sap-ai-sdk/orchestration", () => {
           if (MockOrchestrationEmbeddingClient.embedResponse) {
             const response = MockOrchestrationEmbeddingClient.embedResponse;
             MockOrchestrationEmbeddingClient.embedResponse = undefined;
-            return Promise.resolve(response);
+            return Promise.resolve({
+              getRequestId: () => undefined,
+              response: { headers: {} },
+              ...response,
+            });
           }
           return Promise.resolve({
             getEmbeddings: () => [
               { embedding: [0.1, 0.2, 0.3], index: 0, object: "embedding" },
               { embedding: [0.4, 0.5, 0.6], index: 1, object: "embedding" },
             ],
+            getRequestId: () => "test-orch-embed-request-id",
             getTokenUsage: () => ({ prompt_tokens: 8, total_tokens: 8 }),
+            response: { headers: { "x-request-id": "test-orch-embed-request-id" } },
           });
         },
       );
@@ -121,7 +131,11 @@ vi.mock("@sap-ai-sdk/foundation-models", () => {
           if (MockAzureOpenAiEmbeddingClient.embedResponse) {
             const response = MockAzureOpenAiEmbeddingClient.embedResponse;
             MockAzureOpenAiEmbeddingClient.embedResponse = undefined;
-            return Promise.resolve(response);
+            return Promise.resolve({
+              getRequestId: () => undefined,
+              rawResponse: { headers: {} },
+              ...response,
+            });
           }
           return Promise.resolve({
             _data: {
@@ -131,6 +145,8 @@ vi.mock("@sap-ai-sdk/foundation-models", () => {
               ],
               usage: { prompt_tokens: 8, total_tokens: 8 },
             },
+            getRequestId: () => "test-fm-embed-request-id",
+            rawResponse: { headers: { "x-request-id": "test-fm-embed-request-id" } },
           });
         },
       );
@@ -378,8 +394,13 @@ describe("SAPAIEmbeddingModel", () => {
       expect(result.usage?.tokens).toBe(8);
       expect(result.warnings).toEqual([]);
       expect(result.providerMetadata).toEqual({
-        // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
-        "sap-ai": { model: "text-embedding-ada-002", version: expect.any(String) },
+        "sap-ai": {
+          model: "text-embedding-ada-002",
+          requestId:
+            api === "foundation-models" ? "test-fm-embed-request-id" : "test-orch-embed-request-id",
+          // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+          version: expect.any(String),
+        },
       });
     });
 
@@ -409,6 +430,75 @@ describe("SAPAIEmbeddingModel", () => {
 
       const lastCall = await getLastEmbedCallForApi(api);
       expect(lastCall?.requestConfig).toBeUndefined();
+    });
+
+    it("should surface SDK getRequestId() in providerMetadata['sap-ai'].requestId", async () => {
+      const model = createModelForApi(api);
+      const result = await model.doEmbed({ values: ["a"] });
+
+      const expected =
+        api === "foundation-models" ? "test-fm-embed-request-id" : "test-orch-embed-request-id";
+      expect(
+        (result.providerMetadata?.["sap-ai"] as undefined | { requestId?: string })?.requestId,
+      ).toBe(expected);
+    });
+
+    it("should surface SDK response headers in result.response.headers", async () => {
+      const model = createModelForApi(api);
+      const result = await model.doEmbed({ values: ["a"] });
+
+      const expected =
+        api === "foundation-models" ? "test-fm-embed-request-id" : "test-orch-embed-request-id";
+      expect(result.response?.headers?.["x-request-id"]).toBe(expected);
+    });
+
+    it("should omit requestId when SDK getRequestId() returns undefined", async () => {
+      await setEmbedResponseForApi(
+        api,
+        api === "foundation-models"
+          ? {
+              _data: {
+                data: [{ embedding: [0.1, 0.2], index: 0 }],
+                usage: { prompt_tokens: 1, total_tokens: 1 },
+              },
+              getRequestId: () => undefined,
+              rawResponse: { headers: {} },
+            }
+          : {
+              getEmbeddings: () => [{ embedding: [0.1, 0.2], index: 0, object: "embedding" }],
+              getRequestId: () => undefined,
+              getTokenUsage: () => ({ prompt_tokens: 1, total_tokens: 1 }),
+              response: { headers: {} },
+            },
+      );
+
+      const model = createModelForApi(api);
+      const result = await model.doEmbed({ values: ["a"] });
+
+      expect(result.providerMetadata?.["sap-ai"]).not.toHaveProperty("requestId");
+    });
+
+    it("should not crash when SDK lacks getRequestId or response headers entirely", async () => {
+      await setEmbedResponseForApi(
+        api,
+        api === "foundation-models"
+          ? {
+              _data: {
+                data: [{ embedding: [0.1, 0.2], index: 0 }],
+                usage: { prompt_tokens: 1, total_tokens: 1 },
+              },
+            }
+          : {
+              getEmbeddings: () => [{ embedding: [0.1, 0.2], index: 0, object: "embedding" }],
+              getTokenUsage: () => ({ prompt_tokens: 1, total_tokens: 1 }),
+            },
+      );
+
+      const model = createModelForApi(api);
+      const result = await model.doEmbed({ values: ["a"] });
+
+      expect(result.embeddings).toEqual([[0.1, 0.2]]);
+      expect(result.usage?.tokens).toBe(1);
     });
   });
 

--- a/src/sap-ai-embedding-model.test.ts
+++ b/src/sap-ai-embedding-model.test.ts
@@ -554,26 +554,11 @@ describe("SAPAIEmbeddingModel", () => {
 
     it.each([
       {
-        description: "normalize array header values",
+        description: "wire normalizeHeaders into doEmbed response",
         expected: { "x-multi": "a; b", "x-request-id": "rid" },
         headers: { "x-multi": ["a", "b"], "x-request-id": "rid" },
       },
-      {
-        description: "convert numeric header values to strings",
-        expected: { "content-length": "512", "x-retry-after": "30" },
-        headers: { "content-length": 512, "x-retry-after": 30 },
-      },
-      {
-        description: "skip unsupported header value types",
-        expected: { "x-valid": "keep" },
-        headers: { "x-object": { nested: 1 }, "x-valid": "keep" },
-      },
-      {
-        description: "filter non-string values from array headers",
-        expected: { "x-mixed": "a; b" },
-        headers: { "x-mixed": ["a", 5, null, "b"] },
-      },
-    ])("should $description in doEmbed response", async ({ expected, headers }) => {
+    ])("should $description", async ({ expected, headers }) => {
       const headerBag = headers as Record<string, unknown>;
       await setEmbedResponseForApi(
         api,

--- a/src/sap-ai-embedding-model.test.ts
+++ b/src/sap-ai-embedding-model.test.ts
@@ -532,6 +532,54 @@ describe("SAPAIEmbeddingModel", () => {
         (result.providerMetadata?.["sap-ai"] as undefined | { requestId?: string })?.requestId,
       ).toBe("throwing-rid");
     });
+
+    it.each([
+      {
+        description: "normalize array header values",
+        expected: { "x-multi": "a; b", "x-request-id": "rid" },
+        headers: { "x-multi": ["a", "b"], "x-request-id": "rid" },
+      },
+      {
+        description: "convert numeric header values to strings",
+        expected: { "content-length": "512", "x-retry-after": "30" },
+        headers: { "content-length": 512, "x-retry-after": 30 },
+      },
+      {
+        description: "skip unsupported header value types",
+        expected: { "x-valid": "keep" },
+        headers: { "x-object": { nested: 1 }, "x-valid": "keep" },
+      },
+      {
+        description: "filter non-string values from array headers",
+        expected: { "x-mixed": "a; b" },
+        headers: { "x-mixed": ["a", 5, null, "b"] },
+      },
+    ])("should $description in doEmbed response", async ({ expected, headers }) => {
+      const headerBag = headers as Record<string, unknown>;
+      await setEmbedResponseForApi(
+        api,
+        api === "foundation-models"
+          ? {
+              _data: {
+                data: [{ embedding: [0.1], index: 0 }],
+                usage: { prompt_tokens: 1, total_tokens: 1 },
+              },
+              getRequestId: () => undefined,
+              rawResponse: { headers: headerBag },
+            }
+          : {
+              getEmbeddings: () => [{ embedding: [0.1], index: 0, object: "embedding" }],
+              getRequestId: () => undefined,
+              getTokenUsage: () => ({ prompt_tokens: 1, total_tokens: 1 }),
+              response: { headers: headerBag },
+            },
+      );
+
+      const model = createModelForApi(api);
+      const result = await model.doEmbed({ values: ["a"] });
+
+      expect(result.response?.headers).toEqual(expected);
+    });
   });
 
   describe.each<APIType>(["orchestration", "foundation-models"])(

--- a/src/sap-ai-embedding-model.test.ts
+++ b/src/sap-ai-embedding-model.test.ts
@@ -500,6 +500,38 @@ describe("SAPAIEmbeddingModel", () => {
       expect(result.embeddings).toEqual([[0.1, 0.2]]);
       expect(result.usage?.tokens).toBe(1);
     });
+
+    it("should not crash when SDK rawResponse/response accessor throws", async () => {
+      const baseFM = {
+        _data: {
+          data: [{ embedding: [0.1, 0.2], index: 0 }],
+          usage: { prompt_tokens: 1, total_tokens: 1 },
+        },
+        getRequestId: () => "throwing-rid",
+      };
+      const baseOrch = {
+        getEmbeddings: () => [{ embedding: [0.1, 0.2], index: 0, object: "embedding" }],
+        getRequestId: () => "throwing-rid",
+        getTokenUsage: () => ({ prompt_tokens: 1, total_tokens: 1 }),
+      };
+      const headersField = api === "foundation-models" ? "rawResponse" : "response";
+      const probe = api === "foundation-models" ? { ...baseFM } : { ...baseOrch };
+      Object.defineProperty(probe, headersField, {
+        get(): { headers: Record<string, string> } {
+          throw new Error("rawResponse not available");
+        },
+      });
+      await setEmbedResponseForApi(api, probe);
+
+      const model = createModelForApi(api);
+      const result = await model.doEmbed({ values: ["a"] });
+
+      expect(result.embeddings).toEqual([[0.1, 0.2]]);
+      expect(result.response?.headers).toBeUndefined();
+      expect(
+        (result.providerMetadata?.["sap-ai"] as undefined | { requestId?: string })?.requestId,
+      ).toBe("throwing-rid");
+    });
   });
 
   describe.each<APIType>(["orchestration", "foundation-models"])(

--- a/src/sap-ai-embedding-model.test.ts
+++ b/src/sap-ai-embedding-model.test.ts
@@ -8,6 +8,11 @@ import { clearStrategyCaches } from "./sap-ai-strategy.js";
 
 type APIType = "foundation-models" | "orchestration";
 
+const EMBED_REQUEST_IDS = {
+  "foundation-models": "test-fm-embed-request-id",
+  orchestration: "test-orch-embed-request-id",
+} as const;
+
 interface FMConstructorCall {
   destination: unknown;
   modelDeployment:
@@ -83,9 +88,9 @@ vi.mock("@sap-ai-sdk/orchestration", () => {
               { embedding: [0.1, 0.2, 0.3], index: 0, object: "embedding" },
               { embedding: [0.4, 0.5, 0.6], index: 1, object: "embedding" },
             ],
-            getRequestId: () => "test-orch-embed-request-id",
+            getRequestId: () => EMBED_REQUEST_IDS.orchestration,
             getTokenUsage: () => ({ prompt_tokens: 8, total_tokens: 8 }),
-            response: { headers: { "x-request-id": "test-orch-embed-request-id" } },
+            response: { headers: { "x-request-id": EMBED_REQUEST_IDS.orchestration } },
           });
         },
       );
@@ -145,8 +150,8 @@ vi.mock("@sap-ai-sdk/foundation-models", () => {
               ],
               usage: { prompt_tokens: 8, total_tokens: 8 },
             },
-            getRequestId: () => "test-fm-embed-request-id",
-            rawResponse: { headers: { "x-request-id": "test-fm-embed-request-id" } },
+            getRequestId: () => EMBED_REQUEST_IDS["foundation-models"],
+            rawResponse: { headers: { "x-request-id": EMBED_REQUEST_IDS["foundation-models"] } },
           });
         },
       );
@@ -387,8 +392,7 @@ describe("SAPAIEmbeddingModel", () => {
         values: ["Hello", "World"],
       });
 
-      const expectedRequestId =
-        api === "foundation-models" ? "test-fm-embed-request-id" : "test-orch-embed-request-id";
+      const expectedRequestId = EMBED_REQUEST_IDS[api];
 
       expect(result.embeddings).toEqual([
         [0.1, 0.2, 0.3],
@@ -514,6 +518,38 @@ describe("SAPAIEmbeddingModel", () => {
       expect(
         (result.providerMetadata?.["sap-ai"] as undefined | { requestId?: string })?.requestId,
       ).toBe("throwing-rid");
+    });
+
+    it("should not crash when SDK getRequestId() throws", async () => {
+      const headersField = api === "foundation-models" ? "rawResponse" : "response";
+      const baseFM = {
+        _data: {
+          data: [{ embedding: [0.1, 0.2], index: 0 }],
+          usage: { prompt_tokens: 1, total_tokens: 1 },
+        },
+        getRequestId: () => {
+          throw new Error("getRequestId not available");
+        },
+        [headersField]: { headers: { "x-request-id": "header-rid" } },
+      };
+      const baseOrch = {
+        getEmbeddings: () => [{ embedding: [0.1, 0.2], index: 0, object: "embedding" }],
+        getRequestId: () => {
+          throw new Error("getRequestId not available");
+        },
+        getTokenUsage: () => ({ prompt_tokens: 1, total_tokens: 1 }),
+        [headersField]: { headers: { "x-request-id": "header-rid" } },
+      };
+      const probe = api === "foundation-models" ? baseFM : baseOrch;
+      await setEmbedResponseForApi(api, probe);
+
+      const model = createModelForApi(api);
+      const result = await model.doEmbed({ values: ["a"] });
+
+      expect(result.embeddings).toEqual([[0.1, 0.2]]);
+      expect(
+        (result.providerMetadata?.["sap-ai"] as undefined | { requestId?: string })?.requestId,
+      ).toBe("header-rid");
     });
 
     it.each([

--- a/src/sap-ai-embedding-model.test.ts
+++ b/src/sap-ai-embedding-model.test.ts
@@ -387,6 +387,9 @@ describe("SAPAIEmbeddingModel", () => {
         values: ["Hello", "World"],
       });
 
+      const expectedRequestId =
+        api === "foundation-models" ? "test-fm-embed-request-id" : "test-orch-embed-request-id";
+
       expect(result.embeddings).toEqual([
         [0.1, 0.2, 0.3],
         [0.4, 0.5, 0.6],
@@ -396,12 +399,12 @@ describe("SAPAIEmbeddingModel", () => {
       expect(result.providerMetadata).toEqual({
         "sap-ai": {
           model: "text-embedding-ada-002",
-          requestId:
-            api === "foundation-models" ? "test-fm-embed-request-id" : "test-orch-embed-request-id",
+          requestId: expectedRequestId,
           // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
           version: expect.any(String),
         },
       });
+      expect(result.response?.headers?.["x-request-id"]).toBe(expectedRequestId);
     });
 
     it("should throw TooManyEmbeddingValuesForCallError when exceeding limit", async () => {
@@ -430,26 +433,6 @@ describe("SAPAIEmbeddingModel", () => {
 
       const lastCall = await getLastEmbedCallForApi(api);
       expect(lastCall?.requestConfig).toBeUndefined();
-    });
-
-    it("should surface SDK getRequestId() in providerMetadata['sap-ai'].requestId", async () => {
-      const model = createModelForApi(api);
-      const result = await model.doEmbed({ values: ["a"] });
-
-      const expected =
-        api === "foundation-models" ? "test-fm-embed-request-id" : "test-orch-embed-request-id";
-      expect(
-        (result.providerMetadata?.["sap-ai"] as undefined | { requestId?: string })?.requestId,
-      ).toBe(expected);
-    });
-
-    it("should surface SDK response headers in result.response.headers", async () => {
-      const model = createModelForApi(api);
-      const result = await model.doEmbed({ values: ["a"] });
-
-      const expected =
-        api === "foundation-models" ? "test-fm-embed-request-id" : "test-orch-embed-request-id";
-      expect(result.response?.headers?.["x-request-id"]).toBe(expected);
     });
 
     it("should omit requestId when SDK getRequestId() returns undefined", async () => {

--- a/src/sap-ai-embedding-model.test.ts
+++ b/src/sap-ai-embedding-model.test.ts
@@ -815,6 +815,52 @@ describe("SAPAIEmbeddingModel", () => {
         );
       });
 
+      it("should surface masking_providers deprecation warning on embedding orch path", async () => {
+        const model = createModelForApi("orchestration", "text-embedding-ada-002", {
+          masking: {
+            masking_providers: [
+              {
+                entities: [{ type: "profile-email" }],
+                method: "anonymization",
+                type: "sap_data_privacy_integration",
+              },
+            ],
+          },
+        });
+
+        const result = await model.doEmbed({ values: ["x"] });
+
+        const deprecation = result.warnings.find((w) =>
+          ((w as { message?: string }).message ?? "").includes("masking_providers"),
+        );
+        expect(deprecation).toMatchObject({ type: "other" });
+        expect((deprecation as { message?: string }).message).toBe(
+          "settings.masking.masking_providers is deprecated and will be removed by SAP on 2027-03-20. " +
+            "Migrate to settings.masking.providers.",
+        );
+      });
+
+      it("should not surface deprecation on embedding orch path when providers shape is used", async () => {
+        const model = createModelForApi("orchestration", "text-embedding-ada-002", {
+          masking: {
+            providers: [
+              {
+                entities: [{ type: "profile-email" }],
+                method: "anonymization",
+                type: "sap_data_privacy_integration",
+              },
+            ],
+          },
+        });
+
+        const result = await model.doEmbed({ values: ["x"] });
+
+        const deprecation = result.warnings.find((w) =>
+          ((w as { message?: string }).message ?? "").includes("masking_providers"),
+        );
+        expect(deprecation).toBeUndefined();
+      });
+
       it("should omit masking when empty object", async () => {
         const { MockOrchestrationEmbeddingClient } = await getMockOrchClient();
         const model = createModelForApi("orchestration", "text-embedding-ada-002", {

--- a/src/sap-ai-error.test.ts
+++ b/src/sap-ai-error.test.ts
@@ -153,6 +153,28 @@ describe("normalizeHeaders", () => {
       expect(normalizeHeaders(input)).toBeUndefined();
     });
   });
+
+  describe("case-insensitive keys", () => {
+    it("should lower-case all header keys", () => {
+      expect(
+        normalizeHeaders({
+          "Content-Type": "application/json",
+          "X-Request-Id": "rid",
+          "x-Trace": "t",
+        }),
+      ).toEqual({
+        "content-type": "application/json",
+        "x-request-id": "rid",
+        "x-trace": "t",
+      });
+    });
+
+    it("should resolve mixed-case duplicates with last-write-wins", () => {
+      expect(normalizeHeaders({ "X-Request-Id": "old", "x-request-id": "new" })).toEqual({
+        "x-request-id": "new",
+      });
+    });
+  });
 });
 
 describe("convertSAPErrorToAPICallError", () => {

--- a/src/sap-ai-error.test.ts
+++ b/src/sap-ai-error.test.ts
@@ -174,6 +174,21 @@ describe("normalizeHeaders", () => {
         "x-request-id": "new",
       });
     });
+
+    it("should handle Web Headers instances by iterating via forEach", () => {
+      const headers = new Headers({
+        "Content-Length": "512",
+        "X-Request-Id": "rid-123",
+      });
+      expect(normalizeHeaders(headers)).toEqual({
+        "content-length": "512",
+        "x-request-id": "rid-123",
+      });
+    });
+
+    it("should return undefined for an empty Headers instance", () => {
+      expect(normalizeHeaders(new Headers())).toBeUndefined();
+    });
   });
 });
 

--- a/src/sap-ai-error.ts
+++ b/src/sap-ai-error.ts
@@ -437,6 +437,14 @@ export function convertToAISDKError(
 export function normalizeHeaders(headers: unknown): Record<string, string> | undefined {
   if (!headers || typeof headers !== "object") return undefined;
 
+  if (typeof Headers !== "undefined" && headers instanceof Headers) {
+    const out: Record<string, string> = {};
+    headers.forEach((value, key) => {
+      out[key.toLowerCase()] = value;
+    });
+    return Object.keys(out).length === 0 ? undefined : out;
+  }
+
   const record = headers as Record<string, unknown>;
   const entries = Object.entries(record).flatMap(([key, value]) => {
     const k = key.toLowerCase();

--- a/src/sap-ai-error.ts
+++ b/src/sap-ai-error.ts
@@ -439,13 +439,14 @@ export function normalizeHeaders(headers: unknown): Record<string, string> | und
 
   const record = headers as Record<string, unknown>;
   const entries = Object.entries(record).flatMap(([key, value]) => {
-    if (typeof value === "string") return [[key, value]];
+    const k = key.toLowerCase();
+    if (typeof value === "string") return [[k, value]];
     if (Array.isArray(value)) {
       const strings = value.filter((item): item is string => typeof item === "string").join("; ");
-      return strings.length > 0 ? [[key, strings]] : [];
+      return strings.length > 0 ? [[k, strings]] : [];
     }
     if (typeof value === "number" || typeof value === "boolean") {
-      return [[key, String(value)]];
+      return [[k, String(value)]];
     }
     return [];
   });

--- a/src/sap-ai-language-model-v2.test.ts
+++ b/src/sap-ai-language-model-v2.test.ts
@@ -475,5 +475,74 @@ describe("SAPAILanguageModelV2", () => {
         (result.providerMetadata?.["sap-ai"] as undefined | { requestId?: string })?.requestId,
       ).toBe("v3-to-v2-req-id");
     });
+
+    it("should preserve providerMetadata['sap-ai'].requestId on stream finish through the V3→V2 facade", async () => {
+      const model = new SAPAILanguageModelV2("gpt-4o", {}, defaultConfig);
+
+      const mockInternalStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue({
+            finishReason: { raw: "stop", unified: "stop" },
+            providerMetadata: { "sap-ai": { requestId: "v3-to-v2-stream-req-id" } },
+            type: "finish",
+            usage: { inputTokens: { total: 10 }, outputTokens: { total: 5 } },
+          });
+          controller.close();
+        },
+      });
+
+      const mockDoStream = vi.fn().mockResolvedValue({ stream: mockInternalStream });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      (model as any).internalModel.doStream = mockDoStream;
+
+      const result = await model.doStream({
+        prompt: [{ content: [{ text: "Test", type: "text" }], role: "user" }],
+      });
+
+      const parts = await readAllParts(result.stream);
+      const finish = parts.find((p) => p.type === "finish");
+      expect(
+        (finish as undefined | { providerMetadata?: { "sap-ai"?: { requestId?: string } } })
+          ?.providerMetadata?.["sap-ai"]?.requestId,
+      ).toBe("v3-to-v2-stream-req-id");
+    });
+
+    it("should preserve providerMetadata.cacheUsage on doGenerate through the V3→V2 facade", async () => {
+      const model = new SAPAILanguageModelV2("gpt-4o", {}, defaultConfig);
+
+      const mockDoGenerate = vi.fn().mockResolvedValue({
+        content: [{ text: "Test", type: "text" }],
+        finishReason: { raw: "stop", unified: "stop" },
+        providerMetadata: {
+          "sap-ai": {
+            cacheUsage: { ephemeral_1h_input_tokens: 20, ephemeral_5m_input_tokens: 80 },
+          },
+        },
+        response: { id: "v2-resp-id" },
+        usage: { inputTokens: { total: 100 }, outputTokens: { total: 5 } },
+        warnings: [],
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      (model as any).internalModel.doGenerate = mockDoGenerate;
+
+      const result = await model.doGenerate({
+        prompt: [{ content: [{ text: "Test", type: "text" }], role: "user" }],
+      });
+
+      expect(
+        (
+          result.providerMetadata?.["sap-ai"] as
+            | undefined
+            | {
+                cacheUsage?: {
+                  ephemeral_1h_input_tokens?: number;
+                  ephemeral_5m_input_tokens?: number;
+                };
+              }
+        )?.cacheUsage,
+      ).toEqual({ ephemeral_1h_input_tokens: 20, ephemeral_5m_input_tokens: 80 });
+    });
   });
 });

--- a/src/sap-ai-language-model-v2.test.ts
+++ b/src/sap-ai-language-model-v2.test.ts
@@ -398,5 +398,82 @@ describe("SAPAILanguageModelV2", () => {
         }),
       ).rejects.toThrow("Internal streaming failed");
     });
+
+    it("should preserve masking deprecation warning through the V3\u2192V2 facade", async () => {
+      const model = new SAPAILanguageModelV2("gpt-4o", {}, defaultConfig);
+      const expectedMessage =
+        "settings.masking.masking_providers is deprecated and will be removed by SAP on 2027-03-20. " +
+        "Migrate to settings.masking.providers.";
+
+      const mockDoGenerate = vi.fn().mockResolvedValue({
+        content: [{ text: "Test", type: "text" }],
+        finishReason: { raw: "stop", unified: "stop" },
+        usage: { inputTokens: { total: 10 }, outputTokens: { total: 20 } },
+        warnings: [{ message: expectedMessage, type: "other" }],
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      (model as any).internalModel.doGenerate = mockDoGenerate;
+
+      const result = await model.doGenerate({
+        prompt: [{ content: [{ text: "Test", type: "text" }], role: "user" }],
+      });
+
+      expect(result.warnings).toEqual([{ message: expectedMessage, type: "other" }]);
+    });
+
+    it("should forward tool-level cacheControl through the V2 facade", async () => {
+      const model = new SAPAILanguageModelV2("gpt-4o", {}, defaultConfig);
+
+      const mockDoGenerate = vi.fn().mockResolvedValue({
+        content: [{ text: "Test", type: "text" }],
+        finishReason: { raw: "stop", unified: "stop" },
+        usage: { inputTokens: { total: 5 }, outputTokens: { total: 5 } },
+        warnings: [],
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      (model as any).internalModel.doGenerate = mockDoGenerate;
+
+      const tools = [
+        {
+          inputSchema: { properties: {}, type: "object" as const },
+          name: "weatherLookup",
+          providerOptions: { "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } } },
+          type: "function" as const,
+        },
+      ];
+
+      await model.doGenerate({
+        prompt: [{ content: [{ text: "Test", type: "text" as const }], role: "user" as const }],
+        tools,
+      });
+
+      expect(mockDoGenerate).toHaveBeenCalledWith(expect.objectContaining({ tools }));
+    });
+
+    it("should preserve providerMetadata['sap-ai'].requestId across the V3\u2192V2 cast", async () => {
+      const model = new SAPAILanguageModelV2("gpt-4o", {}, defaultConfig);
+
+      const mockDoGenerate = vi.fn().mockResolvedValue({
+        content: [{ text: "Test", type: "text" }],
+        finishReason: { raw: "stop", unified: "stop" },
+        providerMetadata: { "sap-ai": { requestId: "v3-to-v2-req-id" } },
+        response: { headers: { "x-request-id": "header-rid" }, id: "v2-resp-id" },
+        usage: { inputTokens: { total: 10 }, outputTokens: { total: 20 } },
+        warnings: [],
+      });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      (model as any).internalModel.doGenerate = mockDoGenerate;
+
+      const result = await model.doGenerate({
+        prompt: [{ content: [{ text: "Test", type: "text" }], role: "user" }],
+      });
+
+      expect(
+        (result.providerMetadata?.["sap-ai"] as undefined | { requestId?: string })?.requestId,
+      ).toBe("v3-to-v2-req-id");
+    });
   });
 });

--- a/src/sap-ai-language-model-v2.test.ts
+++ b/src/sap-ai-language-model-v2.test.ts
@@ -399,7 +399,7 @@ describe("SAPAILanguageModelV2", () => {
       ).rejects.toThrow("Internal streaming failed");
     });
 
-    it("should preserve masking deprecation warning through the V3\u2192V2 facade", async () => {
+    it("should preserve masking deprecation warning through the V3→V2 facade", async () => {
       const model = new SAPAILanguageModelV2("gpt-4o", {}, defaultConfig);
       const expectedMessage =
         "settings.masking.masking_providers is deprecated and will be removed by SAP on 2027-03-20. " +
@@ -422,7 +422,7 @@ describe("SAPAILanguageModelV2", () => {
       expect(result.warnings).toEqual([{ message: expectedMessage, type: "other" }]);
     });
 
-    it("should forward tool-level cacheControl through the V2 facade", async () => {
+    it("should forward tool-level cacheControl through the V3→V2 facade", async () => {
       const model = new SAPAILanguageModelV2("gpt-4o", {}, defaultConfig);
 
       const mockDoGenerate = vi.fn().mockResolvedValue({
@@ -452,7 +452,7 @@ describe("SAPAILanguageModelV2", () => {
       expect(mockDoGenerate).toHaveBeenCalledWith(expect.objectContaining({ tools }));
     });
 
-    it("should preserve providerMetadata['sap-ai'].requestId across the V3\u2192V2 cast", async () => {
+    it("should preserve providerMetadata['sap-ai'].requestId through the V3→V2 facade", async () => {
       const model = new SAPAILanguageModelV2("gpt-4o", {}, defaultConfig);
 
       const mockDoGenerate = vi.fn().mockResolvedValue({

--- a/src/sap-ai-language-model-v2.test.ts
+++ b/src/sap-ai-language-model-v2.test.ts
@@ -224,6 +224,42 @@ describe("SAPAILanguageModelV2", () => {
       }
     });
 
+    it("should preserve response-metadata id through the V3→V2 facade", async () => {
+      const model = new SAPAILanguageModelV2("gpt-4o", {}, defaultConfig);
+
+      const mockInternalStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue({
+            id: "v3-to-v2-stream-id",
+            modelId: "gpt-4o",
+            timestamp: new Date(),
+            type: "response-metadata",
+          });
+          controller.enqueue({
+            finishReason: { raw: "stop", unified: "stop" },
+            type: "finish",
+            usage: { inputTokens: { total: 5 }, outputTokens: { total: 5 } },
+          });
+          controller.close();
+        },
+      });
+
+      const mockDoStream = vi.fn().mockResolvedValue({ stream: mockInternalStream });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      (model as any).internalModel.doStream = mockDoStream;
+
+      const result = await model.doStream({
+        prompt: [{ content: [{ text: "Test", type: "text" }], role: "user" }],
+      });
+
+      const parts = await readAllParts(result.stream);
+      const meta = parts.find((p) => p.type === "response-metadata");
+
+      expect(meta).toBeDefined();
+      expect((meta as { id?: string }).id).toBe("v3-to-v2-stream-id");
+    });
+
     it("should propagate errors from internal doGenerate", async () => {
       const model = new SAPAILanguageModelV2("gpt-4o", {}, defaultConfig);
 

--- a/src/sap-ai-language-model-v2.test.ts
+++ b/src/sap-ai-language-model-v2.test.ts
@@ -260,6 +260,79 @@ describe("SAPAILanguageModelV2", () => {
       expect((meta as { id?: string }).id).toBe("v3-to-v2-stream-id");
     });
 
+    it("should preserve providerMetadata.cacheUsage on stream finish through the V3→V2 facade", async () => {
+      const model = new SAPAILanguageModelV2("gpt-4o", {}, defaultConfig);
+
+      const mockInternalStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue({
+            finishReason: { raw: "stop", unified: "stop" },
+            providerMetadata: {
+              "sap-ai": {
+                cacheUsage: { ephemeral_1h_input_tokens: 20, ephemeral_5m_input_tokens: 80 },
+              },
+            },
+            type: "finish",
+            usage: { inputTokens: { total: 100 }, outputTokens: { total: 5 } },
+          });
+          controller.close();
+        },
+      });
+
+      const mockDoStream = vi.fn().mockResolvedValue({ stream: mockInternalStream });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      (model as any).internalModel.doStream = mockDoStream;
+
+      const result = await model.doStream({
+        prompt: [{ content: [{ text: "Test", type: "text" }], role: "user" }],
+      });
+
+      const parts = await readAllParts(result.stream);
+      const finish = parts.find((p) => p.type === "finish");
+
+      expect((finish as { providerMetadata?: unknown }).providerMetadata).toEqual({
+        "sap-ai": {
+          cacheUsage: { ephemeral_1h_input_tokens: 20, ephemeral_5m_input_tokens: 80 },
+        },
+      });
+    });
+
+    it("should preserve stream-start warnings through the V3→V2 facade", async () => {
+      const model = new SAPAILanguageModelV2("gpt-4o", {}, defaultConfig);
+
+      const mockInternalStream = new ReadableStream({
+        start(controller) {
+          controller.enqueue({
+            type: "stream-start",
+            warnings: [{ message: "deprecated knob", type: "other" }],
+          });
+          controller.enqueue({
+            finishReason: { raw: "stop", unified: "stop" },
+            type: "finish",
+            usage: { inputTokens: { total: 5 }, outputTokens: { total: 5 } },
+          });
+          controller.close();
+        },
+      });
+
+      const mockDoStream = vi.fn().mockResolvedValue({ stream: mockInternalStream });
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+      (model as any).internalModel.doStream = mockDoStream;
+
+      const result = await model.doStream({
+        prompt: [{ content: [{ text: "Test", type: "text" }], role: "user" }],
+      });
+
+      const parts = await readAllParts(result.stream);
+      const start = parts.find((p) => p.type === "stream-start");
+
+      expect((start as { warnings?: unknown }).warnings).toEqual([
+        { message: "deprecated knob", type: "other" },
+      ]);
+    });
+
     it("should propagate errors from internal doGenerate", async () => {
       const model = new SAPAILanguageModelV2("gpt-4o", {}, defaultConfig);
 

--- a/src/sap-ai-language-model-v2.test.ts
+++ b/src/sap-ai-language-model-v2.test.ts
@@ -291,47 +291,81 @@ describe("SAPAILanguageModelV2", () => {
       const parts = await readAllParts(result.stream);
       const finish = parts.find((p) => p.type === "finish");
 
-      expect((finish as { providerMetadata?: unknown }).providerMetadata).toEqual({
+      if (finish?.type !== "finish") {
+        throw new Error("expected a finish part");
+      }
+      expect(finish.providerMetadata).toEqual({
         "sap-ai": {
           cacheUsage: { ephemeral_1h_input_tokens: 20, ephemeral_5m_input_tokens: 80 },
         },
       });
     });
 
-    it("should preserve stream-start warnings through the V3→V2 facade", async () => {
-      const model = new SAPAILanguageModelV2("gpt-4o", {}, defaultConfig);
-
-      const mockInternalStream = new ReadableStream({
-        start(controller) {
-          controller.enqueue({
-            type: "stream-start",
-            warnings: [{ message: "deprecated knob", type: "other" }],
-          });
-          controller.enqueue({
-            finishReason: { raw: "stop", unified: "stop" },
-            type: "finish",
-            usage: { inputTokens: { total: 5 }, outputTokens: { total: 5 } },
-          });
-          controller.close();
+    it.each<{
+      description: string;
+      expectedV2: { message: string; type: "other" };
+      v3Warning: { details?: string; feature?: string; message?: string; type: string };
+    }>([
+      {
+        description: "other-type warning forwards verbatim",
+        expectedV2: { message: "deprecated knob", type: "other" },
+        v3Warning: { message: "deprecated knob", type: "other" },
+      },
+      {
+        description: "unsupported warning rewrites to 'Unsupported feature: …'",
+        expectedV2: { message: "Unsupported feature: cacheControl on tool", type: "other" },
+        v3Warning: { feature: "cacheControl on tool", type: "unsupported" },
+      },
+      {
+        description: "compatibility warning rewrites to 'Compatibility mode: …'",
+        expectedV2: {
+          message: "Compatibility mode: legacy responses. switching is recommended",
+          type: "other",
         },
-      });
+        v3Warning: {
+          details: "switching is recommended",
+          feature: "legacy responses",
+          type: "compatibility",
+        },
+      },
+    ])(
+      "should preserve stream-start $description through the V3→V2 facade",
+      async ({ expectedV2, v3Warning }) => {
+        const model = new SAPAILanguageModelV2("gpt-4o", {}, defaultConfig);
 
-      const mockDoStream = vi.fn().mockResolvedValue({ stream: mockInternalStream });
+        const mockInternalStream = new ReadableStream({
+          start(controller) {
+            controller.enqueue({
+              type: "stream-start",
+              warnings: [v3Warning],
+            });
+            controller.enqueue({
+              finishReason: { raw: "stop", unified: "stop" },
+              type: "finish",
+              usage: { inputTokens: { total: 5 }, outputTokens: { total: 5 } },
+            });
+            controller.close();
+          },
+        });
 
-      // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
-      (model as any).internalModel.doStream = mockDoStream;
+        const mockDoStream = vi.fn().mockResolvedValue({ stream: mockInternalStream });
 
-      const result = await model.doStream({
-        prompt: [{ content: [{ text: "Test", type: "text" }], role: "user" }],
-      });
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any, @typescript-eslint/no-unsafe-member-access
+        (model as any).internalModel.doStream = mockDoStream;
 
-      const parts = await readAllParts(result.stream);
-      const start = parts.find((p) => p.type === "stream-start");
+        const result = await model.doStream({
+          prompt: [{ content: [{ text: "Test", type: "text" }], role: "user" }],
+        });
 
-      expect((start as { warnings?: unknown }).warnings).toEqual([
-        { message: "deprecated knob", type: "other" },
-      ]);
-    });
+        const parts = await readAllParts(result.stream);
+        const start = parts.find((p) => p.type === "stream-start");
+
+        if (start?.type !== "stream-start") {
+          throw new Error("expected a stream-start part");
+        }
+        expect(start.warnings).toEqual([expectedV2]);
+      },
+    );
 
     it("should propagate errors from internal doGenerate", async () => {
       const model = new SAPAILanguageModelV2("gpt-4o", {}, defaultConfig);

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -965,6 +965,14 @@ describe("SAPAILanguageModel", () => {
         | {
             completion_tokens: number;
             prompt_tokens: number;
+            prompt_tokens_details?: {
+              cache_creation_token_details?: {
+                ephemeral_1h_input_tokens?: number;
+                ephemeral_5m_input_tokens?: number;
+              };
+              cache_creation_tokens?: number;
+              cached_tokens?: number;
+            };
             total_tokens: number;
           };
     } = {},
@@ -3387,6 +3395,96 @@ describe("SAPAILanguageModel", () => {
         const result = await model.doGenerate({ prompt: createPrompt("Hello") });
 
         expect(result.providerMetadata?.["sap-ai"]).not.toHaveProperty("cacheUsage");
+      });
+    },
+  );
+
+  describe.each<APIType>(["orchestration", "foundation-models"])(
+    "doStream token usage details (%s API)",
+    (api) => {
+      beforeEach(async () => {
+        await resetMockStateForApi(api);
+      });
+
+      it("should map cache_creation_tokens to inputTokens.cacheWrite on the finish event", async () => {
+        await setStreamChunksForApi(api, [
+          createMockStreamChunk({
+            deltaContent: "Hello",
+            finishReason: "stop",
+            usage: {
+              completion_tokens: 5,
+              prompt_tokens: 100,
+              prompt_tokens_details: { cache_creation_tokens: 80, cached_tokens: 20 },
+              total_tokens: 105,
+            },
+          }),
+        ]);
+
+        const model = createModelForApi(api);
+        const result = await model.doStream({ prompt: createPrompt("Hi") });
+        const parts = await readAllStreamParts(result.stream);
+        const finishPart = parts.find((p) => p.type === "finish");
+
+        expect(finishPart).toBeDefined();
+        if (finishPart?.type === "finish") {
+          expect(finishPart.usage.inputTokens.cacheWrite).toBe(80);
+          expect(finishPart.usage.inputTokens.cacheRead).toBe(20);
+        }
+      });
+
+      it("should surface cache_creation_token_details in stream finish providerMetadata.cacheUsage", async () => {
+        await setStreamChunksForApi(api, [
+          createMockStreamChunk({
+            deltaContent: "Hello",
+            finishReason: "stop",
+            usage: {
+              completion_tokens: 5,
+              prompt_tokens: 100,
+              prompt_tokens_details: {
+                cache_creation_token_details: {
+                  ephemeral_1h_input_tokens: 20,
+                  ephemeral_5m_input_tokens: 80,
+                },
+                cache_creation_tokens: 100,
+              },
+              total_tokens: 105,
+            },
+          }),
+        ]);
+
+        const model = createModelForApi(api);
+        const result = await model.doStream({ prompt: createPrompt("Hi") });
+        const parts = await readAllStreamParts(result.stream);
+        const finishPart = parts.find((p) => p.type === "finish");
+
+        expect(finishPart).toBeDefined();
+        if (finishPart?.type === "finish") {
+          expect(finishPart.providerMetadata?.["sap-ai"]).toMatchObject({
+            cacheUsage: {
+              ephemeral_1h_input_tokens: 20,
+              ephemeral_5m_input_tokens: 80,
+            },
+          });
+        }
+      });
+
+      it("should omit cacheUsage on stream finish when ephemeral details are absent", async () => {
+        await setStreamChunksForApi(api, [
+          createMockStreamChunk({
+            deltaContent: "Hello",
+            finishReason: "stop",
+            usage: { completion_tokens: 1, prompt_tokens: 1, total_tokens: 2 },
+          }),
+        ]);
+
+        const model = createModelForApi(api);
+        const result = await model.doStream({ prompt: createPrompt("Hi") });
+        const parts = await readAllStreamParts(result.stream);
+        const finishPart = parts.find((p) => p.type === "finish");
+
+        if (finishPart?.type === "finish") {
+          expect(finishPart.providerMetadata?.["sap-ai"]).not.toHaveProperty("cacheUsage");
+        }
       });
     },
   );

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -2140,6 +2140,16 @@ describe("SAPAILanguageModel", () => {
         input: "function_call",
       },
       {
+        description: "tool_use as tool-calls",
+        expected: "tool-calls",
+        input: "tool_use",
+      },
+      {
+        description: "guardrail_intervened as content-filter",
+        expected: "content-filter",
+        input: "guardrail_intervened",
+      },
+      {
         description: "unknown reason as other",
         expected: "other",
         input: "some_new_unknown_reason",

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -973,8 +973,15 @@ describe("SAPAILanguageModel", () => {
         | undefined
         | {
             completion_tokens: number;
+            completion_tokens_details?: {
+              accepted_prediction_tokens?: number;
+              audio_tokens?: number;
+              reasoning_tokens?: number;
+              rejected_prediction_tokens?: number;
+            };
             prompt_tokens: number;
             prompt_tokens_details?: {
+              audio_tokens?: number;
               cache_creation_token_details?: {
                 ephemeral_1h_input_tokens?: number;
                 ephemeral_5m_input_tokens?: number;
@@ -3775,6 +3782,46 @@ describe("SAPAILanguageModel", () => {
               ephemeral_1h_input_tokens: 20,
               ephemeral_5m_input_tokens: 80,
             },
+          });
+        }
+      });
+
+      it("should preserve usage.raw on stream finish when un-typed token fields are present", async () => {
+        await setStreamChunksForApi(api, [
+          createMockStreamChunk({
+            deltaContent: "Hello",
+            finishReason: "stop",
+            usage: {
+              completion_tokens: 10,
+              completion_tokens_details: {
+                accepted_prediction_tokens: 4,
+                audio_tokens: 2,
+                rejected_prediction_tokens: 1,
+              },
+              prompt_tokens: 20,
+              prompt_tokens_details: { audio_tokens: 3 },
+              total_tokens: 30,
+            },
+          }),
+        ]);
+
+        const model = createModelForApi(api);
+        const result = await model.doStream({ prompt: createPrompt("Hi") });
+        const parts = await readAllStreamParts(result.stream);
+        const finishPart = parts.find((p) => p.type === "finish");
+
+        expect(finishPart).toBeDefined();
+        if (finishPart?.type === "finish") {
+          expect(finishPart.usage.raw).toEqual({
+            completion_tokens: 10,
+            completion_tokens_details: {
+              accepted_prediction_tokens: 4,
+              audio_tokens: 2,
+              rejected_prediction_tokens: 1,
+            },
+            prompt_tokens: 20,
+            prompt_tokens_details: { audio_tokens: 3 },
+            total_tokens: 30,
           });
         }
       });

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -3806,6 +3806,39 @@ describe("SAPAILanguageModel", () => {
         expect(request.masking).toEqual(masking);
       });
 
+      it("should warn when masking is configured with the deprecated masking_providers shape", async () => {
+        const model = createOrchModel("gpt-4o", {
+          masking: {
+            masking_providers: [
+              {
+                entities: [{ type: "profile-email" }],
+                method: "anonymization",
+                type: "sap_data_privacy_integration",
+              },
+            ],
+          },
+        });
+
+        const result = await model.doGenerate({ prompt: createPrompt("Hi") });
+
+        const deprecation = result.warnings.find((w) =>
+          ((w as { message?: string }).message ?? "").includes("masking_providers"),
+        );
+        expect(deprecation).toMatchObject({ type: "other" });
+        expect((deprecation as { message?: string }).message ?? "").toMatch(/2027-03-20/);
+      });
+
+      it("should not warn when masking is absent", async () => {
+        const model = createOrchModel("gpt-4o", {});
+
+        const result = await model.doGenerate({ prompt: createPrompt("Hi") });
+
+        const deprecation = result.warnings.find((w) =>
+          ((w as { message?: string }).message ?? "").includes("masking_providers"),
+        );
+        expect(deprecation).toBeUndefined();
+      });
+
       it("should include filtering module in orchestration config", async () => {
         const filtering = {
           input: {

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -322,7 +322,7 @@ vi.mock("@sap-ai-sdk/foundation-models", () => {
       if (MockAzureOpenAiChatClient.chatCompletionResponse) {
         const response = MockAzureOpenAiChatClient.chatCompletionResponse;
         MockAzureOpenAiChatClient.chatCompletionResponse = undefined;
-        return Promise.resolve(response);
+        return Promise.resolve({ getRequestId: () => undefined, ...response });
       }
 
       const messages = (request as { messages?: unknown[] }).messages;
@@ -343,6 +343,7 @@ vi.mock("@sap-ai-sdk/foundation-models", () => {
         _data: { id: "chatcmpl-fm-test-123" },
         getContent: () => "Hello!",
         getFinishReason: () => "stop",
+        getRequestId: () => "test-request-id",
         getTokenUsage: () => ({
           completion_tokens: 5,
           prompt_tokens: 10,
@@ -417,14 +418,19 @@ vi.mock("@sap-ai-sdk/foundation-models", () => {
       const errorToThrow = MockAzureOpenAiChatClient.streamError;
 
       return Promise.resolve({
-        // Real AzureOpenAiChatCompletionStreamResponse has no _data or rawResponse.
         getFinishReason: () => lastFinishReason,
+        getRequestId: () => "test-stream-request-id",
         getTokenUsage: () =>
           lastTokenUsage ?? {
             completion_tokens: 5,
             prompt_tokens: 10,
             total_tokens: 15,
           },
+        rawResponse: {
+          headers: {
+            "x-request-id": "test-stream-request-id",
+          },
+        },
         stream: {
           *[Symbol.asyncIterator]() {
             for (const chunk of chunks) {
@@ -1724,15 +1730,10 @@ describe("SAPAILanguageModel", () => {
 
       const result = await model.doStream({ prompt });
 
-      if (api === "orchestration") {
-        expect(result.response?.headers).toBeDefined();
-        expect(result.response?.headers).toMatchObject({
-          "x-request-id": "test-stream-request-id",
-        });
-      } else {
-        // Foundation Models stream response has no rawResponse
-        expect(result.response?.headers).toBeUndefined();
-      }
+      expect(result.response?.headers).toBeDefined();
+      expect(result.response?.headers).toMatchObject({
+        "x-request-id": "test-stream-request-id",
+      });
     });
 
     it("should not mutate stream-start warnings when warnings occur during stream", async () => {
@@ -1839,7 +1840,11 @@ describe("SAPAILanguageModel", () => {
         modelId: "gpt-4o",
         type: "response-metadata",
       });
-      expect((responseMetadata as { id: string }).id).toMatch(uuidRegex);
+      if (api === "orchestration") {
+        expect((responseMetadata as { id: string }).id).toMatch(uuidRegex);
+      } else {
+        expect((responseMetadata as { id: string }).id).toBe("test-stream-request-id");
+      }
       expect(parts.some((p) => p.type === "text-delta")).toBe(true);
       expect(parts.some((p) => p.type === "finish")).toBe(true);
 
@@ -1849,13 +1854,13 @@ describe("SAPAILanguageModel", () => {
         expect(finishPart.finishReason).toEqual({ raw: "stop", unified: "stop" });
         const metadata = finishPart.providerMetadata?.["sap-ai"] as Record<string, unknown>;
         expect(metadata.finishReason).toBe("stop");
-        if (api === "orchestration") {
-          expect(metadata.requestId).toBe("test-stream-request-id");
-        } else {
-          expect(metadata.requestId).toBeUndefined();
-        }
+        expect(metadata.requestId).toBe("test-stream-request-id");
         expect(typeof metadata.responseId).toBe("string");
-        expect(metadata.responseId as string).toMatch(uuidRegex);
+        if (api === "orchestration") {
+          expect(metadata.responseId as string).toMatch(uuidRegex);
+        } else {
+          expect(metadata.responseId).toBe("test-stream-request-id");
+        }
         expect(metadata.version).toBeDefined();
       }
     });
@@ -1886,11 +1891,7 @@ describe("SAPAILanguageModel", () => {
           | Record<string, unknown>
           | undefined;
         expect(metadata).toBeDefined();
-        if (api === "orchestration") {
-          expect(metadata?.requestId).toBe("test-stream-request-id");
-        } else {
-          expect(metadata?.requestId).toBeUndefined();
-        }
+        expect(metadata?.requestId).toBe("test-stream-request-id");
       }
     });
 
@@ -1911,15 +1912,11 @@ describe("SAPAILanguageModel", () => {
 
       const MockClient = await getMockClientForApi(api);
       if (MockClient.setStreamResponseOverride) {
-        // Matches real SDK stream shapes:
-        // - Orchestration: _data is {}, getRequestId() returns undefined
-        // - Foundation-models: no _data, no rawResponse
         MockClient.setStreamResponseOverride({
-          ...(api === "orchestration"
-            ? { getRequestId: () => undefined, rawResponse: { headers: {} } }
-            : {}),
           getFinishReason: () => "stop",
+          getRequestId: () => undefined,
           getTokenUsage: () => ({ completion_tokens: 1, prompt_tokens: 2, total_tokens: 3 }),
+          rawResponse: { headers: {} },
           stream: {
             *[Symbol.asyncIterator]() {
               for (const c of chunks) yield c;
@@ -2981,6 +2978,69 @@ describe("SAPAILanguageModel", () => {
 
         await expect(model.doStream({ prompt })).rejects.toThrow("Stream setup failed");
       });
+    });
+  });
+
+  describe("Foundation Models response id fallbacks (foundation-models API)", () => {
+    beforeEach(async () => {
+      await resetMockStateForApi("foundation-models");
+    });
+
+    it("should fall back to response.getRequestId() when _data.id is absent on doGenerate", async () => {
+      const MockClient = await getMockClientForApi("foundation-models");
+      if (!MockClient.setChatCompletionResponse) {
+        throw new Error("mock missing setChatCompletionResponse");
+      }
+      MockClient.setChatCompletionResponse({
+        _data: {},
+        getContent: () => "Hello!",
+        getFinishReason: () => "stop",
+        getRequestId: () => "fm-canonical-req-id",
+        getTokenUsage: () => ({ completion_tokens: 1, prompt_tokens: 1, total_tokens: 2 }),
+        getToolCalls: () => undefined,
+        rawResponse: { headers: { "x-request-id": "fm-canonical-req-id" } },
+      });
+
+      const model = createFMModel();
+      const result = await model.doGenerate({ prompt: createPrompt("Hi") });
+
+      expect(result.response?.id).toBe("fm-canonical-req-id");
+    });
+
+    it("should keep streaming alive when rawResponse access throws", async () => {
+      const MockClient = await getMockClientForApi("foundation-models");
+      if (!MockClient.setStreamResponseOverride) {
+        throw new Error("mock missing setStreamResponseOverride");
+      }
+      MockClient.setStreamResponseOverride({
+        getFinishReason: () => "stop",
+        getRequestId: () => "fm-no-headers-req-id",
+        getTokenUsage: () => ({ completion_tokens: 1, prompt_tokens: 1, total_tokens: 2 }),
+        get rawResponse(): { headers: Record<string, string> } {
+          throw new Error("rawResponse not available (deprecated constructor)");
+        },
+        stream: {
+          // eslint-disable-next-line @typescript-eslint/require-await
+          async *[Symbol.asyncIterator]() {
+            yield {
+              getDeltaContent: () => "ok",
+              getDeltaToolCalls: () => undefined,
+              getFinishReason: () => "stop",
+              getTokenUsage: () => undefined,
+            };
+          },
+        },
+      });
+
+      const model = createFMModel();
+      const result = await model.doStream({ prompt: createPrompt("Hi") });
+
+      expect(result.response?.headers).toBeUndefined();
+
+      const parts = await readAllStreamParts(result.stream);
+      const responseMetadata = parts.find((p) => p.type === "response-metadata");
+      expect(responseMetadata).toBeDefined();
+      expect((responseMetadata as { id: string }).id).toBe("fm-no-headers-req-id");
     });
   });
 

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -3068,6 +3068,72 @@ describe("SAPAILanguageModel", () => {
       expect(result.response?.id).toBeUndefined();
     });
 
+    it("should source providerMetadata.requestId from getRequestId() in preference to the x-request-id header", async () => {
+      const MockClient = await getMockClientForApi("foundation-models");
+      if (!MockClient.setChatCompletionResponse) {
+        throw new Error("mock missing setChatCompletionResponse");
+      }
+      MockClient.setChatCompletionResponse({
+        _data: { id: "completion-1" },
+        getContent: () => "Hello!",
+        getFinishReason: () => "stop",
+        getRequestId: () => "sdk-pipeline-rid",
+        getTokenUsage: () => ({ completion_tokens: 1, prompt_tokens: 1, total_tokens: 2 }),
+        getToolCalls: () => undefined,
+        rawResponse: { headers: { "x-request-id": "http-header-rid" } },
+      });
+
+      const model = createFMModel();
+      const result = await model.doGenerate({ prompt: createPrompt("Hi") });
+
+      const meta = result.providerMetadata?.["sap-ai"] as Record<string, unknown>;
+      expect(meta.requestId).toBe("sdk-pipeline-rid");
+      expect(result.response?.headers?.["x-request-id"]).toBe("http-header-rid");
+    });
+
+    it("should fall back to x-request-id header for providerMetadata.requestId when getRequestId() is undefined", async () => {
+      const MockClient = await getMockClientForApi("foundation-models");
+      if (!MockClient.setChatCompletionResponse) {
+        throw new Error("mock missing setChatCompletionResponse");
+      }
+      MockClient.setChatCompletionResponse({
+        _data: {},
+        getContent: () => "Hello!",
+        getFinishReason: () => "stop",
+        getRequestId: () => undefined,
+        getTokenUsage: () => ({ completion_tokens: 1, prompt_tokens: 1, total_tokens: 2 }),
+        getToolCalls: () => undefined,
+        rawResponse: { headers: { "x-request-id": "http-only-rid" } },
+      });
+
+      const model = createFMModel();
+      const result = await model.doGenerate({ prompt: createPrompt("Hi") });
+
+      const meta = result.providerMetadata?.["sap-ai"] as Record<string, unknown>;
+      expect(meta.requestId).toBe("http-only-rid");
+    });
+
+    it("should omit providerMetadata.requestId when both getRequestId() and the x-request-id header are absent", async () => {
+      const MockClient = await getMockClientForApi("foundation-models");
+      if (!MockClient.setChatCompletionResponse) {
+        throw new Error("mock missing setChatCompletionResponse");
+      }
+      MockClient.setChatCompletionResponse({
+        _data: {},
+        getContent: () => "Hello!",
+        getFinishReason: () => "stop",
+        getRequestId: () => undefined,
+        getTokenUsage: () => ({ completion_tokens: 1, prompt_tokens: 1, total_tokens: 2 }),
+        getToolCalls: () => undefined,
+        rawResponse: { headers: {} },
+      });
+
+      const model = createFMModel();
+      const result = await model.doGenerate({ prompt: createPrompt("Hi") });
+
+      expect(result.providerMetadata?.["sap-ai"]).not.toHaveProperty("requestId");
+    });
+
     it("should keep streaming alive when rawResponse access throws", async () => {
       const MockClient = await getMockClientForApi("foundation-models");
       if (!MockClient.setStreamResponseOverride) {

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -11,6 +11,7 @@ import { beforeEach, describe, expect, it, vi } from "vitest";
 
 import { SAPAILanguageModel } from "./sap-ai-language-model";
 import { clearStrategyCaches } from "./sap-ai-strategy.js";
+import { computeNoCache } from "./strategy-utils.js";
 
 vi.mock("@sap-ai-sdk/orchestration", () => {
   class MockOrchestrationClient {
@@ -3631,7 +3632,7 @@ describe("SAPAILanguageModel", () => {
         expect(result.usage.inputTokens).toEqual({
           cacheRead: 5,
           cacheWrite: 8,
-          noCache: 0,
+          noCache: computeNoCache(10, 5, 8),
           total: 10,
         });
       });

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -3650,6 +3650,115 @@ describe("SAPAILanguageModel", () => {
           expect(finishPart.providerMetadata?.["sap-ai"]).not.toHaveProperty("cacheUsage");
         }
       });
+
+      it("should expose finishReasonMapped on stream finish providerMetadata", async () => {
+        await setStreamChunksForApi(api, [
+          createMockStreamChunk({
+            deltaContent: "Hello",
+            finishReason: "stop",
+            usage: { completion_tokens: 1, prompt_tokens: 1, total_tokens: 2 },
+          }),
+        ]);
+
+        const model = createModelForApi(api);
+        const result = await model.doStream({ prompt: createPrompt("Hi") });
+        const parts = await readAllStreamParts(result.stream);
+        const finishPart = parts.find((p) => p.type === "finish");
+
+        if (finishPart?.type === "finish") {
+          expect(finishPart.providerMetadata?.["sap-ai"]).toMatchObject({
+            finishReason: "stop",
+            finishReasonMapped: { raw: "stop", unified: "stop" },
+          });
+        }
+      });
+
+      it("should fall back to finishReason='unknown' on stream finish when raw is null", async () => {
+        await setStreamChunksForApi(api, [
+          createMockStreamChunk({
+            deltaContent: "Hello",
+            finishReason: null,
+            usage: { completion_tokens: 1, prompt_tokens: 1, total_tokens: 2 },
+          }),
+        ]);
+
+        const model = createModelForApi(api);
+        const result = await model.doStream({ prompt: createPrompt("Hi") });
+        const parts = await readAllStreamParts(result.stream);
+        const finishPart = parts.find((p) => p.type === "finish");
+
+        if (finishPart?.type === "finish") {
+          expect(finishPart.providerMetadata?.["sap-ai"]).toMatchObject({
+            finishReason: "unknown",
+            finishReasonMapped: { raw: undefined, unified: "other" },
+          });
+        }
+      });
+
+      it("should subtract both cacheRead and cacheWrite from noCache on stream finish", async () => {
+        await setStreamChunksForApi(api, [
+          createMockStreamChunk({
+            deltaContent: "Hello",
+            finishReason: "stop",
+            usage: {
+              completion_tokens: 1,
+              prompt_tokens: 100,
+              prompt_tokens_details: { cache_creation_tokens: 30, cached_tokens: 50 },
+              total_tokens: 101,
+            },
+          }),
+        ]);
+
+        const model = createModelForApi(api);
+        const result = await model.doStream({ prompt: createPrompt("Hi") });
+        const parts = await readAllStreamParts(result.stream);
+        const finishPart = parts.find((p) => p.type === "finish");
+
+        if (finishPart?.type === "finish") {
+          expect(finishPart.usage.inputTokens).toEqual({
+            cacheRead: 50,
+            cacheWrite: 30,
+            noCache: 20,
+            total: 100,
+          });
+        }
+      });
+
+      it("should surface cacheUsage on stream finish when only ephemeral_1h is reported", async () => {
+        await setStreamChunksForApi(api, [
+          createMockStreamChunk({
+            deltaContent: "Hello",
+            finishReason: "stop",
+            usage: {
+              completion_tokens: 1,
+              prompt_tokens: 50,
+              prompt_tokens_details: {
+                cache_creation_token_details: { ephemeral_1h_input_tokens: 50 },
+                cache_creation_tokens: 50,
+              },
+              total_tokens: 51,
+            },
+          }),
+        ]);
+
+        const model = createModelForApi(api);
+        const result = await model.doStream({ prompt: createPrompt("Hi") });
+        const parts = await readAllStreamParts(result.stream);
+        const finishPart = parts.find((p) => p.type === "finish");
+
+        if (finishPart?.type === "finish") {
+          expect(finishPart.providerMetadata?.["sap-ai"]).toMatchObject({
+            cacheUsage: { ephemeral_1h_input_tokens: 50 },
+          });
+          expect(
+            (
+              finishPart.providerMetadata?.["sap-ai"]?.cacheUsage as
+                | undefined
+                | { ephemeral_5m_input_tokens?: number }
+            )?.ephemeral_5m_input_tokens,
+          ).toBeUndefined();
+        }
+      });
     },
   );
 

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -3644,7 +3644,7 @@ describe("SAPAILanguageModel", () => {
         });
       });
 
-      it("should populate usage.raw when 2.11 token fields are present", async () => {
+      it("should populate usage.raw when extended token detail fields are present", async () => {
         const MockClient = await getMockClientForApi(api);
         if (!MockClient.setChatCompletionResponse) {
           throw new Error("mock missing setChatCompletionResponse");
@@ -3681,7 +3681,7 @@ describe("SAPAILanguageModel", () => {
         });
       });
 
-      it("should omit usage.raw when no 2.11 token fields are present", async () => {
+      it("should omit usage.raw when no extended token detail fields are present", async () => {
         const model = createModelForApi(api);
         const result = await model.doGenerate({ prompt: createPrompt("Hi") });
 

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -4879,6 +4879,31 @@ describe("SAPAILanguageModel", () => {
           id: "provider-override-id",
         });
       });
+
+      it("should preserve full multi-role conversation in messagesHistory alongside placeholderValues", async () => {
+        const model = createOrchModel("gpt-4o", {
+          placeholderValues: { topic: "math" },
+          promptTemplateRef: { id: "tpl-multi-role" },
+        });
+
+        const prompt: LanguageModelV3Prompt = [
+          { content: "You are a helpful assistant.", role: "system" },
+          { content: [{ text: "Hello", type: "text" }], role: "user" },
+          { content: [{ text: "How can I help?", type: "text" }], role: "assistant" },
+          { content: [{ text: "Explain SAP AI Core.", type: "text" }], role: "user" },
+        ];
+
+        const result = await model.doGenerate({ prompt });
+
+        expectRequestBodyHasMessagesHistory(result);
+
+        const body = result.request?.body as Record<string, unknown>;
+        const history = body.messagesHistory as { role: string }[];
+        expect(history).toHaveLength(4);
+        expect(history.map((m) => m.role)).toEqual(["system", "user", "assistant", "user"]);
+        expect(body).toHaveProperty("placeholderValues");
+        expect(body.placeholderValues).toEqual({ topic: "math" });
+      });
     });
 
     describe("orchestrationConfigRef", () => {

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -5941,7 +5941,7 @@ describe("SAPAILanguageModel", () => {
       await resetMockStateForApi("foundation-models");
     });
 
-    it("orchestration: forwards tool providerOptions['sap-ai'].cacheControl onto ChatCompletionTool.cache_control", async () => {
+    it("should forward tool providerOptions['sap-ai'].cacheControl onto ChatCompletionTool.cache_control (orchestration)", async () => {
       const model = createOrchModel("anthropic--claude-4.5-sonnet");
       await model.doGenerate({
         prompt: createPrompt("Hi"),
@@ -5963,7 +5963,72 @@ describe("SAPAILanguageModel", () => {
       expect(request.tools?.[0]?.cache_control).toEqual({ ttl: "5m", type: "ephemeral" });
     });
 
-    it("orchestration: omits cache_control when providerOptions['sap-ai'] is absent", async () => {
+    it("should forward 1h TTL onto ChatCompletionTool.cache_control (orchestration)", async () => {
+      const model = createOrchModel("anthropic--claude-4.5-sonnet");
+      await model.doGenerate({
+        prompt: createPrompt("Hi"),
+        tools: [
+          {
+            description: "lookup",
+            inputSchema: { properties: {}, required: [], type: "object" },
+            name: "lookup",
+            providerOptions: {
+              "sap-ai": { cacheControl: { ttl: "1h", type: "ephemeral" } },
+            },
+            type: "function",
+          },
+        ],
+      });
+
+      const orch = await getMockOrchClient();
+      const request = orch.lastRequest as { tools?: { cache_control?: unknown }[] };
+      expect(request.tools?.[0]?.cache_control).toEqual({ ttl: "1h", type: "ephemeral" });
+    });
+
+    it("should attach cache_control only to tools with cacheControl directive in a multi-tool array (orchestration)", async () => {
+      const model = createOrchModel("anthropic--claude-4.5-sonnet");
+      await model.doGenerate({
+        prompt: createPrompt("Hi"),
+        tools: [
+          {
+            description: "cached",
+            inputSchema: { properties: {}, required: [], type: "object" },
+            name: "cached",
+            providerOptions: {
+              "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } },
+            },
+            type: "function",
+          },
+          {
+            description: "uncached",
+            inputSchema: { properties: {}, required: [], type: "object" },
+            name: "uncached",
+            type: "function",
+          },
+          {
+            description: "long-cached",
+            inputSchema: { properties: {}, required: [], type: "object" },
+            name: "long-cached",
+            providerOptions: {
+              "sap-ai": { cacheControl: { ttl: "1h", type: "ephemeral" } },
+            },
+            type: "function",
+          },
+        ],
+      });
+
+      const orch = await getMockOrchClient();
+      const tools = (
+        orch.lastRequest as {
+          tools?: { cache_control?: unknown; function: { name: string } }[];
+        }
+      ).tools;
+      expect(tools?.[0]?.cache_control).toEqual({ ttl: "5m", type: "ephemeral" });
+      expect(tools?.[1]).not.toHaveProperty("cache_control");
+      expect(tools?.[2]?.cache_control).toEqual({ ttl: "1h", type: "ephemeral" });
+    });
+
+    it("should omit cache_control when providerOptions['sap-ai'] is absent (orchestration)", async () => {
       const model = createOrchModel("gpt-4o");
       await model.doGenerate({
         prompt: createPrompt("Hi"),
@@ -5982,9 +6047,9 @@ describe("SAPAILanguageModel", () => {
       expect(request.tools?.[0]).not.toHaveProperty("cache_control");
     });
 
-    it("orchestration: silently drops invalid tool cacheControl block", async () => {
+    it("should silently drop invalid tool cacheControl block and surface a parser warning (orchestration)", async () => {
       const model = createOrchModel("anthropic--claude-4.5-sonnet");
-      await model.doGenerate({
+      const result = await model.doGenerate({
         prompt: createPrompt("Hi"),
         tools: [
           {
@@ -6002,9 +6067,14 @@ describe("SAPAILanguageModel", () => {
       const orch = await getMockOrchClient();
       const request = orch.lastRequest as { tools?: { cache_control?: unknown }[] };
       expect(request.tools?.[0]).not.toHaveProperty("cache_control");
+      expect(result.warnings.length).toBeGreaterThan(0);
+      const cacheWarning = result.warnings.find((w) =>
+        ((w as { message?: string }).message ?? "").includes("cacheControl"),
+      );
+      expect(cacheWarning).toMatchObject({ type: "other" });
     });
 
-    it("foundation-models: ignores tool providerOptions['sap-ai'].cacheControl (no plumbing)", async () => {
+    it("should ignore tool providerOptions['sap-ai'].cacheControl with foundation-models API (no plumbing)", async () => {
       const model = createFMModel("gpt-4.1");
       await model.doGenerate({
         prompt: createPrompt("Hi"),

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -3029,7 +3029,7 @@ describe("SAPAILanguageModel", () => {
     });
   });
 
-  describe("Foundation Models response id fallbacks (foundation-models API)", () => {
+  describe("Foundation Models response id and rawResponse resilience (foundation-models API)", () => {
     beforeEach(async () => {
       await resetMockStateForApi("foundation-models");
     });

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -3024,6 +3024,27 @@ describe("SAPAILanguageModel", () => {
       expect(result.response?.id).toBe("fm-canonical-req-id");
     });
 
+    it("should leave response.id undefined when both _data.id and getRequestId() are absent", async () => {
+      const MockClient = await getMockClientForApi("foundation-models");
+      if (!MockClient.setChatCompletionResponse) {
+        throw new Error("mock missing setChatCompletionResponse");
+      }
+      MockClient.setChatCompletionResponse({
+        _data: {},
+        getContent: () => "Hello!",
+        getFinishReason: () => "stop",
+        getRequestId: () => undefined,
+        getTokenUsage: () => ({ completion_tokens: 1, prompt_tokens: 1, total_tokens: 2 }),
+        getToolCalls: () => undefined,
+        rawResponse: { headers: {} },
+      });
+
+      const model = createFMModel();
+      const result = await model.doGenerate({ prompt: createPrompt("Hi") });
+
+      expect(result.response?.id).toBeUndefined();
+    });
+
     it("should keep streaming alive when rawResponse access throws", async () => {
       const MockClient = await getMockClientForApi("foundation-models");
       if (!MockClient.setStreamResponseOverride) {
@@ -3395,6 +3416,60 @@ describe("SAPAILanguageModel", () => {
         const result = await model.doGenerate({ prompt: createPrompt("Hello") });
 
         expect(result.providerMetadata?.["sap-ai"]).not.toHaveProperty("cacheUsage");
+      });
+
+      it("should subtract both cacheRead and cacheWrite from noCache", async () => {
+        const MockClient = await getMockClientForApi(api);
+        if (!MockClient.setChatCompletionResponse) {
+          throw new Error("mock missing setChatCompletionResponse");
+        }
+        MockClient.setChatCompletionResponse(
+          createMockChatResponse(api, {
+            usage: {
+              completion_tokens: 5,
+              prompt_tokens: 100,
+              prompt_tokens_details: { cache_creation_tokens: 30, cached_tokens: 50 },
+              total_tokens: 105,
+            },
+          }),
+        );
+
+        const model = createModelForApi(api);
+        const result = await model.doGenerate({ prompt: createPrompt("Hi") });
+
+        expect(result.usage.inputTokens.cacheRead).toBe(50);
+        expect(result.usage.inputTokens.cacheWrite).toBe(30);
+        expect(result.usage.inputTokens.noCache).toBe(20);
+        expect(result.usage.inputTokens.total).toBe(100);
+      });
+
+      it("should subtract only cacheWrite from noCache when cached is absent", async () => {
+        const MockClient = await getMockClientForApi(api);
+        if (!MockClient.setChatCompletionResponse) {
+          throw new Error("mock missing setChatCompletionResponse");
+        }
+        MockClient.setChatCompletionResponse(
+          createMockChatResponse(api, {
+            usage: {
+              completion_tokens: 5,
+              prompt_tokens: 100,
+              prompt_tokens_details: { cache_creation_tokens: 40 },
+              total_tokens: 105,
+            },
+          }),
+        );
+
+        const model = createModelForApi(api);
+        const result = await model.doGenerate({ prompt: createPrompt("Hi") });
+
+        expect(result.usage.inputTokens.noCache).toBe(60);
+      });
+
+      it("should leave noCache equal to prompt_tokens when no cache breakdown is reported", async () => {
+        const model = createModelForApi(api);
+        const result = await model.doGenerate({ prompt: createPrompt("Hi") });
+
+        expect(result.usage.inputTokens.noCache).toBe(result.usage.inputTokens.total);
       });
     },
   );

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -3565,6 +3565,33 @@ describe("SAPAILanguageModel", () => {
 
         expect(result.usage).not.toHaveProperty("raw");
       });
+
+      it("should populate usage.raw when audio_tokens is present with a zero value", async () => {
+        const MockClient = await getMockClientForApi(api);
+        if (!MockClient.setChatCompletionResponse) {
+          throw new Error("mock missing setChatCompletionResponse");
+        }
+        MockClient.setChatCompletionResponse(
+          createMockChatResponse(api, {
+            usage: {
+              completion_tokens: 5,
+              completion_tokens_details: { audio_tokens: 0 },
+              prompt_tokens: 3,
+              total_tokens: 8,
+            },
+          }),
+        );
+
+        const model = createModelForApi(api);
+        const result = await model.doGenerate({ prompt: createPrompt("Hi") });
+
+        expect(result.usage.raw).toEqual({
+          completion_tokens: 5,
+          completion_tokens_details: { audio_tokens: 0 },
+          prompt_tokens: 3,
+          total_tokens: 8,
+        });
+      });
     },
   );
 

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -3926,6 +3926,28 @@ describe("SAPAILanguageModel", () => {
         expect((deprecation as { message?: string }).message ?? "").toMatch(/2027-03-20/);
       });
 
+      it("should not warn about deprecated masking_providers when orchestrationConfigRef is set", async () => {
+        const model = createOrchModel("gpt-4o", {
+          masking: {
+            masking_providers: [
+              {
+                entities: [{ type: "profile-email" }],
+                method: "anonymization",
+                type: "sap_data_privacy_integration",
+              },
+            ],
+          },
+          orchestrationConfigRef: { id: "server-resolved" },
+        });
+
+        const result = await model.doGenerate({ prompt: createPrompt("Hi") });
+
+        const deprecation = result.warnings.find((w) =>
+          ((w as { message?: string }).message ?? "").includes("masking_providers"),
+        );
+        expect(deprecation).toBeUndefined();
+      });
+
       it("should include filtering module in orchestration config", async () => {
         const filtering = {
           input: {

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -3471,6 +3471,33 @@ describe("SAPAILanguageModel", () => {
 
         expect(result.usage.inputTokens.noCache).toBe(result.usage.inputTokens.total);
       });
+
+      it("should clamp noCache to 0 when cacheRead+cacheWrite exceed prompt_tokens", async () => {
+        const MockClient = await getMockClientForApi(api);
+        if (!MockClient.setChatCompletionResponse) {
+          throw new Error("mock missing setChatCompletionResponse");
+        }
+        MockClient.setChatCompletionResponse(
+          createMockChatResponse(api, {
+            usage: {
+              completion_tokens: 1,
+              prompt_tokens: 10,
+              prompt_tokens_details: { cache_creation_tokens: 8, cached_tokens: 5 },
+              total_tokens: 11,
+            },
+          }),
+        );
+
+        const model = createModelForApi(api);
+        const result = await model.doGenerate({ prompt: createPrompt("Hi") });
+
+        expect(result.usage.inputTokens).toEqual({
+          cacheRead: 5,
+          cacheWrite: 8,
+          noCache: 0,
+          total: 10,
+        });
+      });
     },
   );
 

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -1050,14 +1050,14 @@ describe("SAPAILanguageModel", () => {
       });
 
       describe("model capabilities", () => {
-        const expectedCapabilities = {
-          supportsImageUrls: true,
-          supportsMultipleCompletions: true,
-          supportsParallelToolCalls: true,
-          supportsStreaming: true,
-          supportsStructuredOutputs: true,
-          supportsToolCalls: true,
-        };
+        const v3RemovedFlags = [
+          "supportsImageUrls",
+          "supportsMultipleCompletions",
+          "supportsParallelToolCalls",
+          "supportsStreaming",
+          "supportsStructuredOutputs",
+          "supportsToolCalls",
+        ] as const;
 
         it.each([
           "any-model",
@@ -1067,10 +1067,15 @@ describe("SAPAILanguageModel", () => {
           "amazon--nova-pro",
           "mistralai--mistral-large-instruct",
           "unknown-future-model",
-        ])("should have consistent capabilities for model %s", (modelId) => {
-          const model = createModelForApi(api, modelId);
-          expect(model).toMatchObject(expectedCapabilities);
-        });
+        ])(
+          "should not expose V2-style supports* booleans on model %s (V3 spec uses supportedUrls)",
+          (modelId) => {
+            const model = createModelForApi(api, modelId);
+            for (const flag of v3RemovedFlags) {
+              expect(Object.prototype.hasOwnProperty.call(model, flag)).toBe(false);
+            }
+          },
+        );
       });
     },
   );

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -3171,6 +3171,54 @@ describe("SAPAILanguageModel", () => {
     });
   });
 
+  describe("Orchestration response id priority (orchestration API)", () => {
+    beforeEach(async () => {
+      await resetMockStateForApi("orchestration");
+    });
+
+    it("should prefer _data.final_result.id over getRequestId() on doGenerate", async () => {
+      const MockClient = await getMockClientForApi("orchestration");
+      if (!MockClient.setChatCompletionResponse) {
+        throw new Error("mock missing setChatCompletionResponse");
+      }
+      MockClient.setChatCompletionResponse({
+        _data: { final_result: { id: "orch-data-id" } },
+        getContent: () => "Hello!",
+        getFinishReason: () => "stop",
+        getRequestId: () => "orch-pipeline-id",
+        getTokenUsage: () => ({ completion_tokens: 1, prompt_tokens: 1, total_tokens: 2 }),
+        getToolCalls: () => undefined,
+        rawResponse: { headers: { "x-request-id": "orch-pipeline-id" } },
+      });
+
+      const model = createOrchModel("gpt-4o");
+      const result = await model.doGenerate({ prompt: createPrompt("Hi") });
+
+      expect(result.response?.id).toBe("orch-data-id");
+    });
+
+    it("should fall back to getRequestId() when _data.final_result.id is absent on doGenerate", async () => {
+      const MockClient = await getMockClientForApi("orchestration");
+      if (!MockClient.setChatCompletionResponse) {
+        throw new Error("mock missing setChatCompletionResponse");
+      }
+      MockClient.setChatCompletionResponse({
+        _data: {},
+        getContent: () => "Hello!",
+        getFinishReason: () => "stop",
+        getRequestId: () => "orch-pipeline-id",
+        getTokenUsage: () => ({ completion_tokens: 1, prompt_tokens: 1, total_tokens: 2 }),
+        getToolCalls: () => undefined,
+        rawResponse: { headers: { "x-request-id": "orch-pipeline-id" } },
+      });
+
+      const model = createOrchModel("gpt-4o");
+      const result = await model.doGenerate({ prompt: createPrompt("Hi") });
+
+      expect(result.response?.id).toBe("orch-pipeline-id");
+    });
+  });
+
   describe("doGenerate citations and intermediateFailures (orchestration API)", () => {
     beforeEach(async () => {
       await resetMockStateForApi("orchestration");

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -3860,17 +3860,6 @@ describe("SAPAILanguageModel", () => {
         expect((deprecation as { message?: string }).message ?? "").toMatch(/2027-03-20/);
       });
 
-      it("should not warn when masking is absent", async () => {
-        const model = createOrchModel("gpt-4o", {});
-
-        const result = await model.doGenerate({ prompt: createPrompt("Hi") });
-
-        const deprecation = result.warnings.find((w) =>
-          ((w as { message?: string }).message ?? "").includes("masking_providers"),
-        );
-        expect(deprecation).toBeUndefined();
-      });
-
       it("should include filtering module in orchestration config", async () => {
         const filtering = {
           input: {

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -862,6 +862,10 @@ describe("SAPAILanguageModel", () => {
    * @param overrides.usage.completion_tokens_details.reasoning_tokens - Reasoning token count.
    * @param overrides.usage.prompt_tokens - Prompt token count.
    * @param overrides.usage.prompt_tokens_details - Prompt token details.
+   * @param overrides.usage.prompt_tokens_details.cache_creation_token_details - Anthropic per-TTL cache creation breakdown.
+   * @param overrides.usage.prompt_tokens_details.cache_creation_token_details.ephemeral_1h_input_tokens - Tokens written to the 1h cache.
+   * @param overrides.usage.prompt_tokens_details.cache_creation_token_details.ephemeral_5m_input_tokens - Tokens written to the 5m cache.
+   * @param overrides.usage.prompt_tokens_details.cache_creation_tokens - Tokens written to the prompt cache.
    * @param overrides.usage.prompt_tokens_details.cached_tokens - Cached token count.
    * @param overrides.usage.total_tokens - Total token count.
    * @returns A mock chat response object.
@@ -886,6 +890,11 @@ describe("SAPAILanguageModel", () => {
         };
         prompt_tokens: number;
         prompt_tokens_details?: {
+          cache_creation_token_details?: {
+            ephemeral_1h_input_tokens?: number;
+            ephemeral_5m_input_tokens?: number;
+          };
+          cache_creation_tokens?: number;
           cached_tokens?: number;
         };
         total_tokens: number;
@@ -3313,6 +3322,71 @@ describe("SAPAILanguageModel", () => {
 
         expect(result.usage.inputTokens.cacheRead).toBeUndefined();
         expect(result.usage.outputTokens.reasoning).toBeUndefined();
+      });
+
+      it("should map cache_creation_tokens to inputTokens.cacheWrite", async () => {
+        const MockClient = await getMockClientForApi(api);
+        if (!MockClient.setChatCompletionResponse) {
+          throw new Error("mock missing setChatCompletionResponse");
+        }
+
+        MockClient.setChatCompletionResponse(
+          createMockChatResponse(api, {
+            usage: {
+              completion_tokens: 5,
+              prompt_tokens: 100,
+              prompt_tokens_details: { cache_creation_tokens: 80, cached_tokens: 20 },
+              total_tokens: 105,
+            },
+          }),
+        );
+
+        const model = createModelForApi(api);
+        const result = await model.doGenerate({ prompt: createPrompt("Hello") });
+
+        expect(result.usage.inputTokens.cacheWrite).toBe(80);
+        expect(result.usage.inputTokens.cacheRead).toBe(20);
+      });
+
+      it("should surface cache_creation_token_details in providerMetadata.cacheUsage", async () => {
+        const MockClient = await getMockClientForApi(api);
+        if (!MockClient.setChatCompletionResponse) {
+          throw new Error("mock missing setChatCompletionResponse");
+        }
+
+        MockClient.setChatCompletionResponse(
+          createMockChatResponse(api, {
+            usage: {
+              completion_tokens: 5,
+              prompt_tokens: 100,
+              prompt_tokens_details: {
+                cache_creation_token_details: {
+                  ephemeral_1h_input_tokens: 20,
+                  ephemeral_5m_input_tokens: 80,
+                },
+                cache_creation_tokens: 100,
+              },
+              total_tokens: 105,
+            },
+          }),
+        );
+
+        const model = createModelForApi(api);
+        const result = await model.doGenerate({ prompt: createPrompt("Hello") });
+
+        expect(result.providerMetadata?.["sap-ai"]).toMatchObject({
+          cacheUsage: {
+            ephemeral_1h_input_tokens: 20,
+            ephemeral_5m_input_tokens: 80,
+          },
+        });
+      });
+
+      it("should omit cacheUsage when cache_creation_token_details is absent", async () => {
+        const model = createModelForApi(api);
+        const result = await model.doGenerate({ prompt: createPrompt("Hello") });
+
+        expect(result.providerMetadata?.["sap-ai"]).not.toHaveProperty("cacheUsage");
       });
     },
   );

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -5934,4 +5934,96 @@ describe("SAPAILanguageModel", () => {
       expect(constructorCall?.modelDeployment).not.toHaveProperty("deploymentId");
     });
   });
+
+  describe("tool cache_control plumbing", () => {
+    beforeEach(async () => {
+      await resetMockStateForApi("orchestration");
+      await resetMockStateForApi("foundation-models");
+    });
+
+    it("orchestration: forwards tool providerOptions['sap-ai'].cacheControl onto ChatCompletionTool.cache_control", async () => {
+      const model = createOrchModel("anthropic--claude-4.5-sonnet");
+      await model.doGenerate({
+        prompt: createPrompt("Hi"),
+        tools: [
+          {
+            description: "lookup",
+            inputSchema: { properties: {}, required: [], type: "object" },
+            name: "lookup",
+            providerOptions: {
+              "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } },
+            },
+            type: "function",
+          },
+        ],
+      });
+
+      const orch = await getMockOrchClient();
+      const request = orch.lastRequest as { tools?: { cache_control?: unknown }[] };
+      expect(request.tools?.[0]?.cache_control).toEqual({ ttl: "5m", type: "ephemeral" });
+    });
+
+    it("orchestration: omits cache_control when providerOptions['sap-ai'] is absent", async () => {
+      const model = createOrchModel("gpt-4o");
+      await model.doGenerate({
+        prompt: createPrompt("Hi"),
+        tools: [
+          {
+            description: "lookup",
+            inputSchema: { properties: {}, required: [], type: "object" },
+            name: "lookup",
+            type: "function",
+          },
+        ],
+      });
+
+      const orch = await getMockOrchClient();
+      const request = orch.lastRequest as { tools?: { cache_control?: unknown }[] };
+      expect(request.tools?.[0]).not.toHaveProperty("cache_control");
+    });
+
+    it("orchestration: silently drops invalid tool cacheControl block", async () => {
+      const model = createOrchModel("anthropic--claude-4.5-sonnet");
+      await model.doGenerate({
+        prompt: createPrompt("Hi"),
+        tools: [
+          {
+            description: "lookup",
+            inputSchema: { properties: {}, required: [], type: "object" },
+            name: "lookup",
+            providerOptions: {
+              "sap-ai": { cacheControl: { type: "wrong-type" } },
+            },
+            type: "function",
+          },
+        ],
+      });
+
+      const orch = await getMockOrchClient();
+      const request = orch.lastRequest as { tools?: { cache_control?: unknown }[] };
+      expect(request.tools?.[0]).not.toHaveProperty("cache_control");
+    });
+
+    it("foundation-models: ignores tool providerOptions['sap-ai'].cacheControl (no plumbing)", async () => {
+      const model = createFMModel("gpt-4.1");
+      await model.doGenerate({
+        prompt: createPrompt("Hi"),
+        tools: [
+          {
+            description: "lookup",
+            inputSchema: { properties: {}, required: [], type: "object" },
+            name: "lookup",
+            providerOptions: {
+              "sap-ai": { cacheControl: { ttl: "1h", type: "ephemeral" } },
+            },
+            type: "function",
+          },
+        ],
+      });
+
+      const fm = await getMockClientForApi("foundation-models");
+      const request = fm.lastRequest as { tools?: { cache_control?: unknown }[] };
+      expect(request.tools?.[0]).not.toHaveProperty("cache_control");
+    });
+  });
 });

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -859,9 +859,13 @@ describe("SAPAILanguageModel", () => {
    * @param overrides.usage - Token usage information.
    * @param overrides.usage.completion_tokens - Completion token count.
    * @param overrides.usage.completion_tokens_details - Completion token details.
+   * @param overrides.usage.completion_tokens_details.accepted_prediction_tokens - Predicted-output tokens accepted by the model.
+   * @param overrides.usage.completion_tokens_details.audio_tokens - Audio tokens emitted in the completion.
    * @param overrides.usage.completion_tokens_details.reasoning_tokens - Reasoning token count.
+   * @param overrides.usage.completion_tokens_details.rejected_prediction_tokens - Predicted-output tokens rejected by the model.
    * @param overrides.usage.prompt_tokens - Prompt token count.
    * @param overrides.usage.prompt_tokens_details - Prompt token details.
+   * @param overrides.usage.prompt_tokens_details.audio_tokens - Audio tokens supplied in the prompt.
    * @param overrides.usage.prompt_tokens_details.cache_creation_token_details - Anthropic per-TTL cache creation breakdown.
    * @param overrides.usage.prompt_tokens_details.cache_creation_token_details.ephemeral_1h_input_tokens - Tokens written to the 1h cache.
    * @param overrides.usage.prompt_tokens_details.cache_creation_token_details.ephemeral_5m_input_tokens - Tokens written to the 5m cache.
@@ -886,10 +890,14 @@ describe("SAPAILanguageModel", () => {
       usage?: {
         completion_tokens: number;
         completion_tokens_details?: {
+          accepted_prediction_tokens?: number;
+          audio_tokens?: number;
           reasoning_tokens?: number;
+          rejected_prediction_tokens?: number;
         };
         prompt_tokens: number;
         prompt_tokens_details?: {
+          audio_tokens?: number;
           cache_creation_token_details?: {
             ephemeral_1h_input_tokens?: number;
             ephemeral_5m_input_tokens?: number;
@@ -3507,6 +3515,50 @@ describe("SAPAILanguageModel", () => {
           noCache: 0,
           total: 10,
         });
+      });
+
+      it("should populate usage.raw when 2.11 token fields are present", async () => {
+        const MockClient = await getMockClientForApi(api);
+        if (!MockClient.setChatCompletionResponse) {
+          throw new Error("mock missing setChatCompletionResponse");
+        }
+        MockClient.setChatCompletionResponse(
+          createMockChatResponse(api, {
+            usage: {
+              completion_tokens: 10,
+              completion_tokens_details: {
+                accepted_prediction_tokens: 4,
+                audio_tokens: 2,
+                rejected_prediction_tokens: 1,
+              },
+              prompt_tokens: 20,
+              prompt_tokens_details: { audio_tokens: 3 },
+              total_tokens: 30,
+            },
+          }),
+        );
+
+        const model = createModelForApi(api);
+        const result = await model.doGenerate({ prompt: createPrompt("Hi") });
+
+        expect(result.usage.raw).toEqual({
+          completion_tokens: 10,
+          completion_tokens_details: {
+            accepted_prediction_tokens: 4,
+            audio_tokens: 2,
+            rejected_prediction_tokens: 1,
+          },
+          prompt_tokens: 20,
+          prompt_tokens_details: { audio_tokens: 3 },
+          total_tokens: 30,
+        });
+      });
+
+      it("should omit usage.raw when no 2.11 token fields are present", async () => {
+        const model = createModelForApi(api);
+        const result = await model.doGenerate({ prompt: createPrompt("Hi") });
+
+        expect(result.usage).not.toHaveProperty("raw");
       });
     },
   );

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -3971,7 +3971,10 @@ describe("SAPAILanguageModel", () => {
           ((w as { message?: string }).message ?? "").includes("masking_providers"),
         );
         expect(deprecation).toMatchObject({ type: "other" });
-        expect((deprecation as { message?: string }).message ?? "").toMatch(/2027-03-20/);
+        expect((deprecation as { message?: string }).message).toBe(
+          "settings.masking.masking_providers is deprecated and will be removed by SAP on 2027-03-20. " +
+            "Migrate to settings.masking.providers.",
+        );
       });
 
       it("should not warn about deprecated masking_providers when orchestrationConfigRef is set", async () => {

--- a/src/sap-ai-language-model.ts
+++ b/src/sap-ai-language-model.ts
@@ -78,12 +78,6 @@ interface SAPAILanguageModelConfig {
 export class SAPAILanguageModel implements LanguageModelV3 {
   readonly modelId: SAPAIModelId;
   readonly specificationVersion = "v3";
-  readonly supportsImageUrls: boolean = true;
-  readonly supportsMultipleCompletions: boolean = true;
-  readonly supportsParallelToolCalls: boolean = true;
-  readonly supportsStreaming: boolean = true;
-  readonly supportsStructuredOutputs: boolean = true;
-  readonly supportsToolCalls: boolean = true;
 
   get provider(): string {
     return this.config.provider;

--- a/src/sap-ai-provider-options.test.ts
+++ b/src/sap-ai-provider-options.test.ts
@@ -10,6 +10,7 @@ import {
   getProviderName,
   modelParamsSchema,
   orchestrationConfigRefSchema,
+  parseSAPPartProviderOptions,
   SAP_AI_PROVIDER_NAME,
   sapAIEmbeddingProviderOptions,
   type SAPAIEmbeddingProviderOptions,
@@ -792,5 +793,43 @@ describe("validateEmbeddingModelParamsSettings", () => {
       dimensions: 1536,
       normalize: true,
     });
+  });
+});
+
+describe("parseSAPPartProviderOptions", () => {
+  it("returns parsed options when cacheControl is valid", () => {
+    expect(
+      parseSAPPartProviderOptions({
+        "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } },
+      }),
+    ).toEqual({ cacheControl: { ttl: "5m", type: "ephemeral" } });
+  });
+
+  it("returns undefined when sap-ai block is absent", () => {
+    expect(parseSAPPartProviderOptions({ anthropic: { cacheControl: {} } })).toBeUndefined();
+    expect(parseSAPPartProviderOptions({})).toBeUndefined();
+  });
+
+  it("returns undefined for primitives, arrays, null, and undefined", () => {
+    expect(parseSAPPartProviderOptions(null)).toBeUndefined();
+    expect(parseSAPPartProviderOptions(undefined)).toBeUndefined();
+    expect(parseSAPPartProviderOptions("string")).toBeUndefined();
+    expect(parseSAPPartProviderOptions(42)).toBeUndefined();
+    expect(parseSAPPartProviderOptions([{ "sap-ai": {} }])).toBeUndefined();
+  });
+
+  it.each([
+    { input: { cacheControl: { type: "permanent" } }, label: "wrong literal type" },
+    { input: { cacheControl: { ttl: "10m", type: "ephemeral" } }, label: "unsupported ttl" },
+    { input: { cacheControl: 42 }, label: "non-object cacheControl" },
+    { input: { cacheControl: "string" }, label: "string cacheControl" },
+  ])("silently drops invalid cacheControl ($label)", ({ input }) => {
+    expect(parseSAPPartProviderOptions({ "sap-ai": input })).toBeUndefined();
+  });
+
+  it("does not throw on circular input", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(() => parseSAPPartProviderOptions(circular)).not.toThrow();
   });
 });

--- a/src/sap-ai-provider-options.test.ts
+++ b/src/sap-ai-provider-options.test.ts
@@ -845,8 +845,9 @@ describe("parseSAPPartProviderOptions", () => {
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatchObject({ type: "other" });
     const message = (warnings[0] as { message?: string }).message ?? "";
-    expect(message).toMatch(/cacheControl/);
-    expect(message).toMatch(/dropped/);
+    expect(message).toMatch(
+      /^providerOptions\['sap-ai'\]\.cacheControl\.ttl is invalid: [^]+\. The directive was dropped\.$/,
+    );
   });
 
   it("should not push warnings when block is absent", () => {

--- a/src/sap-ai-provider-options.test.ts
+++ b/src/sap-ai-provider-options.test.ts
@@ -797,7 +797,7 @@ describe("validateEmbeddingModelParamsSettings", () => {
 });
 
 describe("parseSAPPartProviderOptions", () => {
-  it("returns parsed options when cacheControl is valid", () => {
+  it("should return parsed options when cacheControl is valid", () => {
     expect(
       parseSAPPartProviderOptions({
         "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } },
@@ -805,12 +805,12 @@ describe("parseSAPPartProviderOptions", () => {
     ).toEqual({ cacheControl: { ttl: "5m", type: "ephemeral" } });
   });
 
-  it("returns undefined when sap-ai block is absent", () => {
+  it("should return undefined when sap-ai block is absent", () => {
     expect(parseSAPPartProviderOptions({ anthropic: { cacheControl: {} } })).toBeUndefined();
     expect(parseSAPPartProviderOptions({})).toBeUndefined();
   });
 
-  it("returns undefined for primitives, arrays, null, and undefined", () => {
+  it("should return undefined for primitives, arrays, null, and undefined", () => {
     expect(parseSAPPartProviderOptions(null)).toBeUndefined();
     expect(parseSAPPartProviderOptions(undefined)).toBeUndefined();
     expect(parseSAPPartProviderOptions("string")).toBeUndefined();
@@ -828,13 +828,13 @@ describe("parseSAPPartProviderOptions", () => {
     expect(parseSAPPartProviderOptions({ "sap-ai": input })).toBeUndefined();
   });
 
-  it("does not throw on circular input", () => {
+  it("should not throw on circular input", () => {
     const circular: Record<string, unknown> = {};
     circular.self = circular;
     expect(() => parseSAPPartProviderOptions(circular)).not.toThrow();
   });
 
-  it("pushes one warning per Zod issue when invalid block is provided", () => {
+  it("should push one warning per Zod issue when invalid block is provided", () => {
     const warnings: SharedV3Warning[] = [];
     const result = parseSAPPartProviderOptions(
       { "sap-ai": { cacheControl: { ttl: "10m", type: "ephemeral" } } },
@@ -849,13 +849,13 @@ describe("parseSAPPartProviderOptions", () => {
     expect(message).toMatch(/dropped/);
   });
 
-  it("does not push warnings when block is absent", () => {
+  it("should not push warnings when block is absent", () => {
     const warnings: SharedV3Warning[] = [];
     parseSAPPartProviderOptions({ anthropic: { cacheControl: {} } }, warnings);
     expect(warnings).toHaveLength(0);
   });
 
-  it("does not push warnings when block is valid", () => {
+  it("should not push warnings when block is valid", () => {
     const warnings: SharedV3Warning[] = [];
     parseSAPPartProviderOptions(
       { "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } } },
@@ -864,7 +864,7 @@ describe("parseSAPPartProviderOptions", () => {
     expect(warnings).toHaveLength(0);
   });
 
-  it("dedupes warnings across repeated invocations sharing the same sink", () => {
+  it("should dedupe warnings across repeated invocations sharing the same sink", () => {
     const warnings: SharedV3Warning[] = [];
     parseSAPPartProviderOptions(
       { "sap-ai": { cacheControl: { ttl: "10m", type: "ephemeral" } } },
@@ -881,7 +881,7 @@ describe("parseSAPPartProviderOptions", () => {
     expect(warnings).toHaveLength(1);
   });
 
-  it("keeps distinct warnings when issues differ across invocations", () => {
+  it("should keep distinct warnings when issues differ across invocations", () => {
     const warnings: SharedV3Warning[] = [];
     parseSAPPartProviderOptions(
       { "sap-ai": { cacheControl: { ttl: "10m", type: "ephemeral" } } },

--- a/src/sap-ai-provider-options.test.ts
+++ b/src/sap-ai-provider-options.test.ts
@@ -863,4 +863,31 @@ describe("parseSAPPartProviderOptions", () => {
     );
     expect(warnings).toHaveLength(0);
   });
+
+  it("dedupes warnings across repeated invocations sharing the same sink", () => {
+    const warnings: SharedV3Warning[] = [];
+    parseSAPPartProviderOptions(
+      { "sap-ai": { cacheControl: { ttl: "10m", type: "ephemeral" } } },
+      warnings,
+    );
+    parseSAPPartProviderOptions(
+      { "sap-ai": { cacheControl: { ttl: "10m", type: "ephemeral" } } },
+      warnings,
+    );
+    parseSAPPartProviderOptions(
+      { "sap-ai": { cacheControl: { ttl: "10m", type: "ephemeral" } } },
+      warnings,
+    );
+    expect(warnings).toHaveLength(1);
+  });
+
+  it("keeps distinct warnings when issues differ across invocations", () => {
+    const warnings: SharedV3Warning[] = [];
+    parseSAPPartProviderOptions(
+      { "sap-ai": { cacheControl: { ttl: "10m", type: "ephemeral" } } },
+      warnings,
+    );
+    parseSAPPartProviderOptions({ "sap-ai": { cacheControl: { type: "permanent" } } }, warnings);
+    expect(warnings).toHaveLength(2);
+  });
 });

--- a/src/sap-ai-provider-options.test.ts
+++ b/src/sap-ai-provider-options.test.ts
@@ -819,6 +819,7 @@ describe("parseSAPPartProviderOptions", () => {
   });
 
   it.each([
+    { input: { cacheControl: {} }, label: "empty cacheControl" },
     { input: { cacheControl: { type: "permanent" } }, label: "wrong literal type" },
     { input: { cacheControl: { ttl: "10m", type: "ephemeral" } }, label: "unsupported ttl" },
     { input: { cacheControl: 42 }, label: "non-object cacheControl" },

--- a/src/sap-ai-provider-options.test.ts
+++ b/src/sap-ai-provider-options.test.ts
@@ -832,4 +832,34 @@ describe("parseSAPPartProviderOptions", () => {
     circular.self = circular;
     expect(() => parseSAPPartProviderOptions(circular)).not.toThrow();
   });
+
+  it("pushes one warning per Zod issue when invalid block is provided", () => {
+    const warnings: SharedV3Warning[] = [];
+    const result = parseSAPPartProviderOptions(
+      { "sap-ai": { cacheControl: { ttl: "10m", type: "ephemeral" } } },
+      warnings,
+    );
+
+    expect(result).toBeUndefined();
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({ type: "other" });
+    const message = (warnings[0] as { message?: string }).message ?? "";
+    expect(message).toMatch(/cacheControl/);
+    expect(message).toMatch(/dropped/);
+  });
+
+  it("does not push warnings when block is absent", () => {
+    const warnings: SharedV3Warning[] = [];
+    parseSAPPartProviderOptions({ anthropic: { cacheControl: {} } }, warnings);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("does not push warnings when block is valid", () => {
+    const warnings: SharedV3Warning[] = [];
+    parseSAPPartProviderOptions(
+      { "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } } },
+      warnings,
+    );
+    expect(warnings).toHaveLength(0);
+  });
 });

--- a/src/sap-ai-provider-options.ts
+++ b/src/sap-ai-provider-options.ts
@@ -135,10 +135,15 @@ export const sapAIPartProviderOptionsSchema = z.object({
 /**
  * Callback that consumes per-message-part `providerOptions` and returns the
  * `sap-ai` slice (e.g. `cacheControl`) when present and valid.
+ *
+ * Optional `warnings` sink receives one entry per Zod issue when the block
+ * fails validation; invalid blocks are still dropped silently from the parsed
+ * result so the converter can keep producing a request.
  * @internal
  */
 export type ParsePartProviderOptions = (
   providerOptions: unknown,
+  warnings?: SharedV3Warning[],
 ) => SAPAIPartProviderOptions | undefined;
 
 /** @internal */
@@ -147,14 +152,17 @@ export type SAPAIPartProviderOptions = z.infer<typeof sapAIPartProviderOptionsSc
 /**
  * Parses per-part `providerOptions['sap-ai']`.
  *
- * Returns `undefined` when the block is absent or invalid; invalid blocks are
- * dropped silently because the converter has no warnings sink.
+ * Returns `undefined` when the block is absent or invalid. When `warnings` is
+ * provided, Zod validation issues are surfaced as `SharedV3Warning` entries so
+ * the strategy layer can forward them to the AI SDK call result.
  * @param providerOptions - Part-level providerOptions bag.
+ * @param warnings - Optional sink for Zod validation issues.
  * @returns Validated per-part options, or undefined.
  * @internal
  */
 export function parseSAPPartProviderOptions(
   providerOptions: unknown,
+  warnings?: SharedV3Warning[],
 ): SAPAIPartProviderOptions | undefined {
   if (!providerOptions || typeof providerOptions !== "object") {
     return undefined;
@@ -164,7 +172,19 @@ export function parseSAPPartProviderOptions(
     return undefined;
   }
   const parsed = sapAIPartProviderOptionsSchema.safeParse(block);
-  return parsed.success ? parsed.data : undefined;
+  if (parsed.success) {
+    return parsed.data;
+  }
+  if (warnings) {
+    for (const issue of parsed.error.issues) {
+      const path = issue.path.join(".");
+      warnings.push({
+        message: `providerOptions['sap-ai']${path ? `.${path}` : ""} is invalid: ${issue.message}. The directive was dropped.`,
+        type: "other",
+      });
+    }
+  }
+  return undefined;
 }
 
 /** @internal */

--- a/src/sap-ai-provider-options.ts
+++ b/src/sap-ai-provider-options.ts
@@ -133,12 +133,9 @@ export const sapAIPartProviderOptionsSchema = z.object({
 });
 
 /**
- * Callback that consumes per-message-part `providerOptions` and returns the
- * `sap-ai` slice (e.g. `cacheControl`) when present and valid.
- *
- * Optional `warnings` sink receives one entry per Zod issue when the block
- * fails validation; invalid blocks are still dropped silently from the parsed
- * result so the converter can keep producing a request.
+ * Callback that reads per-message-part `providerOptions` and returns the validated
+ * `sap-ai` slice (e.g. `cacheControl`), or `undefined` when absent or invalid.
+ * Optional `warnings` sink receives one entry per Zod issue.
  * @internal
  */
 export type ParsePartProviderOptions = (

--- a/src/sap-ai-provider-options.ts
+++ b/src/sap-ai-provider-options.ts
@@ -110,6 +110,53 @@ export function validateModelParamsWithWarnings(
 /** @internal */
 export const sapAIApiTypeSchema = z.enum(["orchestration", "foundation-models"]);
 
+/**
+ * Anthropic prompt-caching directive accepted on V3 message-parts via
+ * `providerOptions['sap-ai'].cacheControl`.
+ * @internal
+ */
+export const cacheControlSchema = z.object({
+  ttl: z.enum(["5m", "1h"]).optional(),
+  type: z.literal("ephemeral"),
+});
+
+/** @internal */
+export type CacheControl = z.infer<typeof cacheControlSchema>;
+
+/**
+ * Per-message-part SAP AI provider options read from
+ * `LanguageModelV3*Part.providerOptions['sap-ai']`.
+ * @internal
+ */
+export const sapAIPartProviderOptionsSchema = z.object({
+  cacheControl: cacheControlSchema.optional(),
+});
+
+/** @internal */
+export type SAPAIPartProviderOptions = z.infer<typeof sapAIPartProviderOptionsSchema>;
+
+/**
+ * Parses per-part `providerOptions['sap-ai']`.
+ *
+ * Returns `undefined` when the block is absent or invalid; invalid blocks are
+ * dropped silently because the converter has no warnings sink.
+ * @param providerOptions - Part-level providerOptions bag.
+ * @returns Validated per-part options, or undefined.
+ */
+export function parseSAPPartProviderOptions(
+  providerOptions: unknown,
+): SAPAIPartProviderOptions | undefined {
+  if (!providerOptions || typeof providerOptions !== "object") {
+    return undefined;
+  }
+  const block = (providerOptions as Record<string, unknown>)[SAP_AI_PROVIDER_NAME];
+  if (block === undefined) {
+    return undefined;
+  }
+  const parsed = sapAIPartProviderOptionsSchema.safeParse(block);
+  return parsed.success ? parsed.data : undefined;
+}
+
 /** @internal */
 export const promptTemplateScopeSchema = z.enum(["tenant", "resource_group"]);
 

--- a/src/sap-ai-provider-options.ts
+++ b/src/sap-ai-provider-options.ts
@@ -178,10 +178,10 @@ export function parseSAPPartProviderOptions(
   if (warnings) {
     for (const issue of parsed.error.issues) {
       const path = issue.path.join(".");
-      warnings.push({
-        message: `providerOptions['sap-ai']${path ? `.${path}` : ""} is invalid: ${issue.message}. The directive was dropped.`,
-        type: "other",
-      });
+      const message = `providerOptions['sap-ai']${path ? `.${path}` : ""} is invalid: ${issue.message}. The directive was dropped.`;
+      if (!warnings.some((w) => (w as { message?: string }).message === message)) {
+        warnings.push({ message, type: "other" });
+      }
     }
   }
   return undefined;

--- a/src/sap-ai-provider-options.ts
+++ b/src/sap-ai-provider-options.ts
@@ -132,6 +132,15 @@ export const sapAIPartProviderOptionsSchema = z.object({
   cacheControl: cacheControlSchema.optional(),
 });
 
+/**
+ * Callback that consumes per-message-part `providerOptions` and returns the
+ * `sap-ai` slice (e.g. `cacheControl`) when present and valid.
+ * @internal
+ */
+export type ParsePartProviderOptions = (
+  providerOptions: unknown,
+) => SAPAIPartProviderOptions | undefined;
+
 /** @internal */
 export type SAPAIPartProviderOptions = z.infer<typeof sapAIPartProviderOptionsSchema>;
 
@@ -142,6 +151,7 @@ export type SAPAIPartProviderOptions = z.infer<typeof sapAIPartProviderOptionsSc
  * dropped silently because the converter has no warnings sink.
  * @param providerOptions - Part-level providerOptions bag.
  * @returns Validated per-part options, or undefined.
+ * @internal
  */
 export function parseSAPPartProviderOptions(
   providerOptions: unknown,

--- a/src/sap-ai-settings.ts
+++ b/src/sap-ai-settings.ts
@@ -131,7 +131,7 @@ export interface OrchestrationModelSettings {
   readonly grounding?: GroundingModule;
   /** @default false */
   readonly includeReasoning?: boolean;
-  readonly masking?: MaskingModule;
+  readonly masking?: MaskingModule | { providers: MaskingModule["masking_providers"] };
   readonly modelParams?: OrchestrationModelParams;
   readonly modelVersion?: string;
   /**
@@ -218,7 +218,7 @@ export type SAPAIDefaultSettingsConfig =
 export interface SAPAIEmbeddingSettings {
   readonly api?: SAPAIApiType;
   /** Orchestration API only. */
-  readonly masking?: MaskingModule;
+  readonly masking?: MaskingModule | { providers: MaskingModule["masking_providers"] };
   /** @default 2048 */
   readonly maxEmbeddingsPerCall?: number;
   readonly modelParams?: FoundationModelsEmbeddingParams | Record<string, unknown>;
@@ -290,7 +290,7 @@ export interface SAPAISettings {
   /** @default false */
   readonly includeReasoning?: boolean;
   /** Orchestration API only. */
-  readonly masking?: MaskingModule;
+  readonly masking?: MaskingModule | { providers: MaskingModule["masking_providers"] };
   readonly modelParams?: CommonModelParams;
   readonly modelVersion?: string;
   /** Orchestration API only. */

--- a/src/sap-ai-validation.test.ts
+++ b/src/sap-ai-validation.test.ts
@@ -1,13 +1,20 @@
+import type { SharedV3Warning } from "@ai-sdk/provider";
+
 /**
  * Tests for SAP AI API validation functions.
  */
 import { describe, expect, it } from "vitest";
 
-import type { SAPAIEmbeddingSettings, SAPAIModelSettings } from "./sap-ai-settings";
+import type {
+  OrchestrationModelSettings,
+  SAPAIEmbeddingSettings,
+  SAPAIModelSettings,
+} from "./sap-ai-settings";
 
 import { ApiSwitchError, UnsupportedFeatureError } from "./sap-ai-error";
 import {
   getEffectiveEscapeTemplatePlaceholders,
+  pushDeprecatedMaskingProvidersWarning,
   resolveApi,
   validateApiInput,
   validateSettings,
@@ -870,5 +877,57 @@ describe("getEffectiveEscapeTemplatePlaceholders", () => {
         getEffectiveEscapeTemplatePlaceholders("orchestration", mockSettings({}), undefined),
       ).toBe(true);
     });
+  });
+});
+
+describe("pushDeprecatedMaskingProvidersWarning", () => {
+  it("should push a deprecation warning when only masking_providers is set", () => {
+    const warnings: SharedV3Warning[] = [];
+    const settings = {
+      masking: { masking_providers: [] },
+    } as unknown as OrchestrationModelSettings;
+
+    pushDeprecatedMaskingProvidersWarning(settings, warnings);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({ type: "other" });
+    const message = (warnings[0] as { message?: string }).message ?? "";
+    expect(message).toMatch(/masking_providers/);
+    expect(message).toMatch(/deprecated/);
+    expect(message).toMatch(/2027-03-20/);
+  });
+
+  it("should not push a warning when providers is set (preferred shape)", () => {
+    const warnings: SharedV3Warning[] = [];
+    const settings = {
+      masking: { providers: [] },
+    } as unknown as OrchestrationModelSettings;
+
+    pushDeprecatedMaskingProvidersWarning(settings, warnings);
+
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("should not push a warning when both shapes are set (preferred shape wins)", () => {
+    const warnings: SharedV3Warning[] = [];
+    const settings = {
+      masking: { masking_providers: [], providers: [] },
+    } as unknown as OrchestrationModelSettings;
+
+    pushDeprecatedMaskingProvidersWarning(settings, warnings);
+
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("should not push a warning when masking is absent", () => {
+    const warnings: SharedV3Warning[] = [];
+    pushDeprecatedMaskingProvidersWarning({}, warnings);
+    expect(warnings).toHaveLength(0);
+  });
+
+  it("should tolerate undefined settings", () => {
+    const warnings: SharedV3Warning[] = [];
+    pushDeprecatedMaskingProvidersWarning(undefined, warnings);
+    expect(warnings).toHaveLength(0);
   });
 });

--- a/src/sap-ai-validation.test.ts
+++ b/src/sap-ai-validation.test.ts
@@ -14,9 +14,9 @@ import type {
 import { ApiSwitchError, UnsupportedFeatureError } from "./sap-ai-error";
 import {
   getEffectiveEscapeTemplatePlaceholders,
-  pushDeprecatedMaskingProvidersWarning,
   resolveApi,
   validateApiInput,
+  validateMaskingProvidersDeprecation,
   validateSettings,
 } from "./sap-ai-validation";
 
@@ -880,14 +880,14 @@ describe("getEffectiveEscapeTemplatePlaceholders", () => {
   });
 });
 
-describe("pushDeprecatedMaskingProvidersWarning", () => {
+describe("validateMaskingProvidersDeprecation", () => {
   it("should push a deprecation warning when only masking_providers is set", () => {
     const warnings: SharedV3Warning[] = [];
     const settings = {
       masking: { masking_providers: [] },
     } as unknown as OrchestrationModelSettings;
 
-    pushDeprecatedMaskingProvidersWarning(settings, warnings);
+    validateMaskingProvidersDeprecation(settings, warnings);
 
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatchObject({ type: "other" });
@@ -903,7 +903,7 @@ describe("pushDeprecatedMaskingProvidersWarning", () => {
       masking: { providers: [] },
     } as unknown as OrchestrationModelSettings;
 
-    pushDeprecatedMaskingProvidersWarning(settings, warnings);
+    validateMaskingProvidersDeprecation(settings, warnings);
 
     expect(warnings).toHaveLength(0);
   });
@@ -914,7 +914,7 @@ describe("pushDeprecatedMaskingProvidersWarning", () => {
       masking: { masking_providers: [], providers: [] },
     } as unknown as OrchestrationModelSettings;
 
-    pushDeprecatedMaskingProvidersWarning(settings, warnings);
+    validateMaskingProvidersDeprecation(settings, warnings);
 
     expect(warnings).toHaveLength(0);
   });
@@ -925,7 +925,7 @@ describe("pushDeprecatedMaskingProvidersWarning", () => {
       masking: { masking_providers: [{ a: 1 }], providers: undefined },
     } as unknown as OrchestrationModelSettings;
 
-    pushDeprecatedMaskingProvidersWarning(settings, warnings);
+    validateMaskingProvidersDeprecation(settings, warnings);
 
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatchObject({ type: "other" });
@@ -934,13 +934,13 @@ describe("pushDeprecatedMaskingProvidersWarning", () => {
 
   it("should not push a warning when masking is absent", () => {
     const warnings: SharedV3Warning[] = [];
-    pushDeprecatedMaskingProvidersWarning({}, warnings);
+    validateMaskingProvidersDeprecation({}, warnings);
     expect(warnings).toHaveLength(0);
   });
 
   it("should tolerate undefined settings", () => {
     const warnings: SharedV3Warning[] = [];
-    pushDeprecatedMaskingProvidersWarning(undefined, warnings);
+    validateMaskingProvidersDeprecation(undefined, warnings);
     expect(warnings).toHaveLength(0);
   });
 });

--- a/src/sap-ai-validation.test.ts
+++ b/src/sap-ai-validation.test.ts
@@ -881,6 +881,10 @@ describe("getEffectiveEscapeTemplatePlaceholders", () => {
 });
 
 describe("validateMaskingProvidersDeprecation", () => {
+  const expectedMessage =
+    "settings.masking.masking_providers is deprecated and will be removed by SAP on 2027-03-20. " +
+    "Migrate to settings.masking.providers.";
+
   it("should push a deprecation warning when only masking_providers is set", () => {
     const warnings: SharedV3Warning[] = [];
     const settings = {
@@ -891,10 +895,7 @@ describe("validateMaskingProvidersDeprecation", () => {
 
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatchObject({ type: "other" });
-    const message = (warnings[0] as { message?: string }).message ?? "";
-    expect(message).toMatch(/masking_providers/);
-    expect(message).toMatch(/deprecated/);
-    expect(message).toMatch(/2027-03-20/);
+    expect((warnings[0] as { message?: string }).message).toBe(expectedMessage);
   });
 
   it("should not push a warning when providers is set (preferred shape)", () => {
@@ -929,7 +930,7 @@ describe("validateMaskingProvidersDeprecation", () => {
 
     expect(warnings).toHaveLength(1);
     expect(warnings[0]).toMatchObject({ type: "other" });
-    expect((warnings[0] as { message?: string }).message ?? "").toMatch(/2027-03-20/);
+    expect((warnings[0] as { message?: string }).message).toBe(expectedMessage);
   });
 
   it("should not push a warning when masking is absent", () => {

--- a/src/sap-ai-validation.test.ts
+++ b/src/sap-ai-validation.test.ts
@@ -919,6 +919,19 @@ describe("pushDeprecatedMaskingProvidersWarning", () => {
     expect(warnings).toHaveLength(0);
   });
 
+  it("should push a warning when providers is set to undefined alongside masking_providers", () => {
+    const warnings: SharedV3Warning[] = [];
+    const settings = {
+      masking: { masking_providers: [{ a: 1 }], providers: undefined },
+    } as unknown as OrchestrationModelSettings;
+
+    pushDeprecatedMaskingProvidersWarning(settings, warnings);
+
+    expect(warnings).toHaveLength(1);
+    expect(warnings[0]).toMatchObject({ type: "other" });
+    expect((warnings[0] as { message?: string }).message ?? "").toMatch(/2027-03-20/);
+  });
+
   it("should not push a warning when masking is absent", () => {
     const warnings: SharedV3Warning[] = [];
     pushDeprecatedMaskingProvidersWarning({}, warnings);

--- a/src/sap-ai-validation.ts
+++ b/src/sap-ai-validation.ts
@@ -357,8 +357,9 @@ export function pushDeprecatedMaskingProvidersWarning(
   if (!masking) {
     return;
   }
-  const hasDeprecated = "masking_providers" in masking;
-  const hasPreferred = "providers" in masking;
+  const maskingRecord = masking as unknown as Record<string, unknown>;
+  const hasDeprecated = maskingRecord.masking_providers !== undefined;
+  const hasPreferred = maskingRecord.providers !== undefined;
   if (hasDeprecated && !hasPreferred) {
     warnings.push({
       message:

--- a/src/sap-ai-validation.ts
+++ b/src/sap-ai-validation.ts
@@ -339,38 +339,6 @@ export function mergeSettingsWithApi<T extends { api?: string }>(
 }
 
 /**
- * Pushes a SharedV3Warning when orchestration `masking` is configured with the deprecated
- * `masking_providers` shape and no `providers` block.
- *
- * The SAP AI SDK orchestration schema 2.11 marks `masking_providers` as deprecated with a
- * removal target of 2027-03-20. Callers that opt into the deprecated shape silently lose
- * the masking module on that date; surfacing the warning preserves a migration path.
- * @param modelSettings - Resolved model settings (orchestration variant carries the masking module).
- * @param warnings - Sink that collects the deprecation warning when it applies.
- * @internal
- */
-export function pushDeprecatedMaskingProvidersWarning(
-  modelSettings: SAPAISettings | undefined,
-  warnings: SharedV3Warning[],
-): void {
-  const masking = (modelSettings as OrchestrationModelSettings | undefined)?.masking;
-  if (!masking) {
-    return;
-  }
-  const maskingRecord = masking as unknown as Record<string, unknown>;
-  const hasDeprecated = maskingRecord.masking_providers !== undefined;
-  const hasPreferred = maskingRecord.providers !== undefined;
-  if (hasDeprecated && !hasPreferred) {
-    warnings.push({
-      message:
-        "settings.masking.masking_providers is deprecated and will be removed by SAP on 2027-03-20. " +
-        "Migrate to settings.masking.providers.",
-      type: "other",
-    });
-  }
-}
-
-/**
  * Resolves the effective API type using the full precedence chain.
  * @param providerApi - Provider-level API type.
  * @param modelApi - Model-level API type.
@@ -397,6 +365,38 @@ export function validateApiInput(api: unknown): void {
       `Invalid API type: ${JSON.stringify(api)}. ` +
         `Valid values are: ${VALID_API_TYPES.map((t) => `"${t}"`).join(", ")}`,
     );
+  }
+}
+
+/**
+ * Pushes a SharedV3Warning when orchestration `masking` is configured with the deprecated
+ * `masking_providers` shape and no `providers` block.
+ *
+ * The SAP AI SDK orchestration schema 2.11 marks `masking_providers` as deprecated with a
+ * removal target of 2027-03-20. Callers that opt into the deprecated shape silently lose
+ * the masking module on that date; surfacing the warning preserves a migration path.
+ * @param modelSettings - Resolved model settings (orchestration variant carries the masking module).
+ * @param warnings - Sink that collects the deprecation warning when it applies.
+ * @internal
+ */
+export function validateMaskingProvidersDeprecation(
+  modelSettings: SAPAISettings | undefined,
+  warnings: SharedV3Warning[],
+): void {
+  const masking = (modelSettings as OrchestrationModelSettings | undefined)?.masking;
+  if (!masking) {
+    return;
+  }
+  const maskingRecord = masking as unknown as Record<string, unknown>;
+  const hasDeprecated = maskingRecord.masking_providers !== undefined;
+  const hasPreferred = maskingRecord.providers !== undefined;
+  if (hasDeprecated && !hasPreferred) {
+    warnings.push({
+      message:
+        "settings.masking.masking_providers is deprecated and will be removed by SAP on 2027-03-20. " +
+        "Migrate to settings.masking.providers.",
+      type: "other",
+    });
   }
 }
 

--- a/src/sap-ai-validation.ts
+++ b/src/sap-ai-validation.ts
@@ -371,19 +371,19 @@ export function validateApiInput(api: unknown): void {
 /**
  * Pushes a deprecation warning when `settings.masking` carries `masking_providers`
  * without a `providers` block.
- * @param modelSettings - Resolved model settings (orchestration variant carries the masking module).
+ * @param modelSettings - Resolved model settings (LM or embedding) that may carry a `masking` module.
  * @param warnings - Sink that collects the deprecation warning when it applies.
  * @internal
  */
 export function validateMaskingProvidersDeprecation(
-  modelSettings: SAPAISettings | undefined,
+  modelSettings: undefined | { masking?: unknown },
   warnings: SharedV3Warning[],
 ): void {
-  const masking = (modelSettings as OrchestrationModelSettings | undefined)?.masking;
-  if (!masking) {
+  const masking = modelSettings?.masking;
+  if (!masking || typeof masking !== "object") {
     return;
   }
-  const maskingRecord = masking as unknown as Record<string, unknown>;
+  const maskingRecord = masking as Record<string, unknown>;
   const hasDeprecated = maskingRecord.masking_providers !== undefined;
   const hasPreferred = maskingRecord.providers !== undefined;
   if (hasDeprecated && !hasPreferred) {

--- a/src/sap-ai-validation.ts
+++ b/src/sap-ai-validation.ts
@@ -1,4 +1,6 @@
 /** Validation and resolution functions for SAP AI API-specific features. */
+import type { SharedV3Warning } from "@ai-sdk/provider";
+
 import type {
   FoundationModelsModelSettings,
   OrchestrationModelSettings,
@@ -334,6 +336,37 @@ export function mergeSettingsWithApi<T extends { api?: string }>(
     ...deepMerge(defaultSettings, callSettings as Record<string, unknown>),
     api: callSettings.api ?? (defaultSettings?.api as string | undefined) ?? fallbackApi,
   } as T;
+}
+
+/**
+ * Pushes a SharedV3Warning when orchestration `masking` is configured with the deprecated
+ * `masking_providers` shape and no `providers` block.
+ *
+ * The SAP AI SDK orchestration schema 2.11 marks `masking_providers` as deprecated with a
+ * removal target of 2027-03-20. Callers that opt into the deprecated shape silently lose
+ * the masking module on that date; surfacing the warning preserves a migration path.
+ * @param modelSettings - Resolved model settings (orchestration variant carries the masking module).
+ * @param warnings - Sink that collects the deprecation warning when it applies.
+ * @internal
+ */
+export function pushDeprecatedMaskingProvidersWarning(
+  modelSettings: SAPAISettings | undefined,
+  warnings: SharedV3Warning[],
+): void {
+  const masking = (modelSettings as OrchestrationModelSettings | undefined)?.masking;
+  if (!masking) {
+    return;
+  }
+  const hasDeprecated = "masking_providers" in masking;
+  const hasPreferred = "providers" in masking;
+  if (hasDeprecated && !hasPreferred) {
+    warnings.push({
+      message:
+        "settings.masking.masking_providers is deprecated and will be removed by SAP on 2027-03-20. " +
+        "Migrate to settings.masking.providers.",
+      type: "other",
+    });
+  }
 }
 
 /**

--- a/src/sap-ai-validation.ts
+++ b/src/sap-ai-validation.ts
@@ -369,12 +369,8 @@ export function validateApiInput(api: unknown): void {
 }
 
 /**
- * Pushes a SharedV3Warning when orchestration `masking` is configured with the deprecated
- * `masking_providers` shape and no `providers` block.
- *
- * The SAP AI SDK orchestration schema 2.11 marks `masking_providers` as deprecated with a
- * removal target of 2027-03-20. Callers that opt into the deprecated shape silently lose
- * the masking module on that date; surfacing the warning preserves a migration path.
+ * Pushes a deprecation warning when `settings.masking` carries `masking_providers`
+ * without a `providers` block.
  * @param modelSettings - Resolved model settings (orchestration variant carries the masking module).
  * @param warnings - Sink that collects the deprecation warning when it applies.
  * @internal

--- a/src/strategy-utils.test.ts
+++ b/src/strategy-utils.test.ts
@@ -99,11 +99,9 @@ describe("convertToolsToSAPFormat", () => {
 
 describe("mapFinishReason", () => {
   it.each<[string, "content-filter" | "stop" | "tool-calls"]>([
-    ["tool_use", "tool-calls"],
     ["TOOL_USE", "tool-calls"],
-    ["guardrail_intervened", "content-filter"],
     ["GUARDRAIL_INTERVENED", "content-filter"],
-  ])("should map %s to %s", (raw, unified) => {
+  ])("should lower-case %s before mapping to %s", (raw, unified) => {
     expect(mapFinishReason(raw)).toEqual({ raw, unified });
   });
 });

--- a/src/strategy-utils.test.ts
+++ b/src/strategy-utils.test.ts
@@ -6,7 +6,9 @@ import { describe, expect, it } from "vitest";
 
 import { parseSAPPartProviderOptions } from "./sap-ai-provider-options.js";
 import {
+  computeNoCache,
   convertToolsToSAPFormat,
+  extractCompletionId,
   mapFinishReason,
   sanitizeAsJSONArray,
   sanitizeAsJSONObject,
@@ -29,12 +31,12 @@ const buildFunctionTool = (
 });
 
 describe("convertToolsToSAPFormat", () => {
-  it("returns no tools and no warnings for an empty list", () => {
+  it("should return no tools and no warnings for an empty list", () => {
     const result = convertToolsToSAPFormat<ChatCompletionTool>([]);
     expect(result).toEqual({ tools: undefined, warnings: [] });
   });
 
-  it("forwards a valid cacheControl directive onto the SAP tool envelope", () => {
+  it("should forward a valid cacheControl directive onto the SAP tool envelope", () => {
     const tools: LanguageModelV3FunctionTool[] = [
       buildFunctionTool({
         providerOptions: { "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } } },
@@ -48,7 +50,7 @@ describe("convertToolsToSAPFormat", () => {
     expect(cached.cache_control).toEqual({ ttl: "5m", type: "ephemeral" });
   });
 
-  it("pushes a parser warning into the sink when an invalid cacheControl block is provided", () => {
+  it("should push a parser warning into the sink when an invalid cacheControl block is provided", () => {
     const sink: SharedV3Warning[] = [];
     const tools: LanguageModelV3FunctionTool[] = [
       buildFunctionTool({
@@ -67,7 +69,7 @@ describe("convertToolsToSAPFormat", () => {
     expect((sink[0] as { message?: string }).message ?? "").toMatch(/cacheControl/);
   });
 
-  it("does not push warnings when no parser is supplied (Foundation Models path)", () => {
+  it("should not push warnings when no parser is supplied (Foundation Models path)", () => {
     const sink: SharedV3Warning[] = [];
     const tools: LanguageModelV3FunctionTool[] = [
       buildFunctionTool({
@@ -124,5 +126,69 @@ describe("sanitizeAsJSONObject", () => {
     const circular: Record<string, unknown> = {};
     circular.self = circular;
     expect(sanitizeAsJSONObject(circular)).toEqual({});
+  });
+});
+
+describe("extractCompletionId", () => {
+  it.each<
+    [string, { _data?: unknown; getRequestId?: unknown }, readonly string[], string | undefined]
+  >([
+    ["resolve a single-segment path", { _data: { id: "x1" } }, ["id"], "x1"],
+    [
+      "walk a dotted nested path",
+      { _data: { final_result: { id: "x2" } } },
+      ["final_result", "id"],
+      "x2",
+    ],
+    [
+      "fall back to getRequestId when path missing",
+      { _data: {}, getRequestId: () => "rid" },
+      ["id"],
+      "rid",
+    ],
+    [
+      "return undefined when both sources are absent",
+      { _data: {}, getRequestId: () => undefined },
+      ["id"],
+      undefined,
+    ],
+    ["tolerate non-function getRequestId", { _data: {}, getRequestId: 42 }, ["id"], undefined],
+    [
+      "tolerate throwing getRequestId",
+      {
+        _data: {},
+        getRequestId: () => {
+          throw new Error("nope");
+        },
+      },
+      ["id"],
+      undefined,
+    ],
+  ])("should %s", (_label, response, path, expected) => {
+    expect(
+      extractCompletionId(
+        response as { _data?: unknown; getRequestId?: () => string | undefined },
+        path,
+      ),
+    ).toBe(expected);
+  });
+});
+
+describe("computeNoCache", () => {
+  it.each<[string, number | undefined, number | undefined, number | undefined, number | undefined]>(
+    [
+      ["return undefined when promptTokens is unknown", undefined, 5, 3, undefined],
+      [
+        "return promptTokens unchanged when no cache breakdown is reported",
+        100,
+        undefined,
+        undefined,
+        100,
+      ],
+      ["subtract both cache buckets from promptTokens", 100, 30, 20, 50],
+      ["clamp the result at zero on overflow", 10, 8, 5, 0],
+    ],
+  )("should %s", (_label, prompt, cached, cacheWrite, expected) => {
+    expect(computeNoCache(prompt, cached, cacheWrite)).toBe(expected);
   });
 });

--- a/src/strategy-utils.test.ts
+++ b/src/strategy-utils.test.ts
@@ -190,6 +190,12 @@ describe("sanitizeAsJSONObject", () => {
     });
   });
 
+  it("should coerce nested bigint values recursively", () => {
+    expect(sanitizeAsJSONObject({ outer: { inner: [1n, { deep: -9007199254740993n }] } })).toEqual({
+      outer: { inner: ["1", { deep: "-9007199254740993" }] },
+    });
+  });
+
   it("should serialize Date values to ISO strings via JSON.stringify default", () => {
     const date = new Date("2026-01-02T03:04:05.000Z");
     expect(sanitizeAsJSONObject({ at: date })).toEqual({ at: "2026-01-02T03:04:05.000Z" });

--- a/src/strategy-utils.test.ts
+++ b/src/strategy-utils.test.ts
@@ -5,7 +5,7 @@ import type { LanguageModelV3FunctionTool, SharedV3Warning } from "@ai-sdk/provi
 import { describe, expect, it } from "vitest";
 
 import { parseSAPPartProviderOptions } from "./sap-ai-provider-options.js";
-import { convertToolsToSAPFormat, type SAPTool } from "./strategy-utils.js";
+import { convertToolsToSAPFormat, mapFinishReason, type SAPTool } from "./strategy-utils.js";
 
 interface ChatCompletionTool extends SAPTool<unknown> {
   function: { description?: string; name: string; parameters: unknown };
@@ -71,5 +71,16 @@ describe("convertToolsToSAPFormat", () => {
 
     expect(result.tools?.[0]).not.toHaveProperty("cache_control");
     expect(sink).toHaveLength(0);
+  });
+});
+
+describe("mapFinishReason", () => {
+  it.each<[string, "content-filter" | "stop" | "tool-calls"]>([
+    ["tool_use", "tool-calls"],
+    ["TOOL_USE", "tool-calls"],
+    ["guardrail_intervened", "content-filter"],
+    ["GUARDRAIL_INTERVENED", "content-filter"],
+  ])("should map %s to %s", (raw, unified) => {
+    expect(mapFinishReason(raw)).toEqual({ raw, unified });
   });
 });

--- a/src/strategy-utils.test.ts
+++ b/src/strategy-utils.test.ts
@@ -40,7 +40,9 @@ describe("convertToolsToSAPFormat", () => {
         providerOptions: { "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } } },
       }),
     ];
-    const result = convertToolsToSAPFormat<ChatCompletionTool>(tools, parseSAPPartProviderOptions);
+    const result = convertToolsToSAPFormat<ChatCompletionTool>(tools, {
+      parser: parseSAPPartProviderOptions,
+    });
 
     const cached = result.tools?.[0] as { cache_control?: unknown };
     expect(cached.cache_control).toEqual({ ttl: "5m", type: "ephemeral" });
@@ -53,11 +55,10 @@ describe("convertToolsToSAPFormat", () => {
         providerOptions: { "sap-ai": { cacheControl: { type: "wrong-type" } } },
       }),
     ];
-    const result = convertToolsToSAPFormat<ChatCompletionTool>(
-      tools,
-      parseSAPPartProviderOptions,
-      sink,
-    );
+    const result = convertToolsToSAPFormat<ChatCompletionTool>(tools, {
+      parser: parseSAPPartProviderOptions,
+      warnings: sink,
+    });
 
     const tool = result.tools?.[0] as { cache_control?: unknown };
     expect(tool).not.toHaveProperty("cache_control");
@@ -73,7 +74,7 @@ describe("convertToolsToSAPFormat", () => {
         providerOptions: { "sap-ai": { cacheControl: { type: "wrong-type" } } },
       }),
     ];
-    const result = convertToolsToSAPFormat<ChatCompletionTool>(tools, undefined, sink);
+    const result = convertToolsToSAPFormat<ChatCompletionTool>(tools, { warnings: sink });
 
     expect(result.tools?.[0]).not.toHaveProperty("cache_control");
     expect(sink).toHaveLength(0);

--- a/src/strategy-utils.test.ts
+++ b/src/strategy-utils.test.ts
@@ -1,0 +1,75 @@
+/** Unit tests for shared strategy utilities. */
+
+import type { LanguageModelV3FunctionTool, SharedV3Warning } from "@ai-sdk/provider";
+
+import { describe, expect, it } from "vitest";
+
+import { parseSAPPartProviderOptions } from "./sap-ai-provider-options.js";
+import { convertToolsToSAPFormat, type SAPTool } from "./strategy-utils.js";
+
+interface ChatCompletionTool extends SAPTool<unknown> {
+  function: { description?: string; name: string; parameters: unknown };
+  type: "function";
+}
+
+const buildFunctionTool = (
+  overrides: Partial<LanguageModelV3FunctionTool> = {},
+): LanguageModelV3FunctionTool => ({
+  description: "lookup",
+  inputSchema: { properties: {}, required: [], type: "object" },
+  name: "lookup",
+  type: "function",
+  ...overrides,
+});
+
+describe("convertToolsToSAPFormat", () => {
+  it("returns no tools and no warnings for an empty list", () => {
+    const result = convertToolsToSAPFormat<ChatCompletionTool>([]);
+    expect(result).toEqual({ tools: undefined, warnings: [] });
+  });
+
+  it("forwards a valid cacheControl directive onto the SAP tool envelope", () => {
+    const tools: LanguageModelV3FunctionTool[] = [
+      buildFunctionTool({
+        providerOptions: { "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } } },
+      }),
+    ];
+    const result = convertToolsToSAPFormat<ChatCompletionTool>(tools, parseSAPPartProviderOptions);
+
+    const cached = result.tools?.[0] as { cache_control?: unknown };
+    expect(cached.cache_control).toEqual({ ttl: "5m", type: "ephemeral" });
+  });
+
+  it("pushes a parser warning into the sink when an invalid cacheControl block is provided", () => {
+    const sink: SharedV3Warning[] = [];
+    const tools: LanguageModelV3FunctionTool[] = [
+      buildFunctionTool({
+        providerOptions: { "sap-ai": { cacheControl: { type: "wrong-type" } } },
+      }),
+    ];
+    const result = convertToolsToSAPFormat<ChatCompletionTool>(
+      tools,
+      parseSAPPartProviderOptions,
+      sink,
+    );
+
+    const tool = result.tools?.[0] as { cache_control?: unknown };
+    expect(tool).not.toHaveProperty("cache_control");
+    expect(sink.length).toBeGreaterThan(0);
+    expect(sink[0]).toMatchObject({ type: "other" });
+    expect((sink[0] as { message?: string }).message ?? "").toMatch(/cacheControl/);
+  });
+
+  it("does not push warnings when no parser is supplied (Foundation Models path)", () => {
+    const sink: SharedV3Warning[] = [];
+    const tools: LanguageModelV3FunctionTool[] = [
+      buildFunctionTool({
+        providerOptions: { "sap-ai": { cacheControl: { type: "wrong-type" } } },
+      }),
+    ];
+    const result = convertToolsToSAPFormat<ChatCompletionTool>(tools, undefined, sink);
+
+    expect(result.tools?.[0]).not.toHaveProperty("cache_control");
+    expect(sink).toHaveLength(0);
+  });
+});

--- a/src/strategy-utils.test.ts
+++ b/src/strategy-utils.test.ts
@@ -124,6 +124,10 @@ describe("sanitizeAsJSONArray", () => {
     circular.self = circular;
     expect(sanitizeAsJSONArray([circular])).toEqual([]);
   });
+
+  it("should coerce bigint entries to decimal strings rather than dropping the payload", () => {
+    expect(sanitizeAsJSONArray([1, 2n, "x"])).toEqual([1, "2", "x"]);
+  });
 });
 
 describe("sanitizeAsJSONObject", () => {
@@ -139,6 +143,18 @@ describe("sanitizeAsJSONObject", () => {
     const circular: Record<string, unknown> = {};
     circular.self = circular;
     expect(sanitizeAsJSONObject(circular)).toEqual({});
+  });
+
+  it("should coerce bigint values to decimal strings rather than dropping the payload", () => {
+    expect(sanitizeAsJSONObject({ a: 1, b: 9007199254740993n })).toEqual({
+      a: 1,
+      b: "9007199254740993",
+    });
+  });
+
+  it("should serialize Date values to ISO strings via JSON.stringify default", () => {
+    const date = new Date("2026-01-02T03:04:05.000Z");
+    expect(sanitizeAsJSONObject({ at: date })).toEqual({ at: "2026-01-02T03:04:05.000Z" });
   });
 });
 

--- a/src/strategy-utils.test.ts
+++ b/src/strategy-utils.test.ts
@@ -5,7 +5,13 @@ import type { LanguageModelV3FunctionTool, SharedV3Warning } from "@ai-sdk/provi
 import { describe, expect, it } from "vitest";
 
 import { parseSAPPartProviderOptions } from "./sap-ai-provider-options.js";
-import { convertToolsToSAPFormat, mapFinishReason, type SAPTool } from "./strategy-utils.js";
+import {
+  convertToolsToSAPFormat,
+  mapFinishReason,
+  sanitizeAsJSONArray,
+  sanitizeAsJSONObject,
+  type SAPTool,
+} from "./strategy-utils.js";
 
 interface ChatCompletionTool extends SAPTool<unknown> {
   function: { description?: string; name: string; parameters: unknown };
@@ -82,5 +88,40 @@ describe("mapFinishReason", () => {
     ["GUARDRAIL_INTERVENED", "content-filter"],
   ])("should map %s to %s", (raw, unified) => {
     expect(mapFinishReason(raw)).toEqual({ raw, unified });
+  });
+});
+
+describe("sanitizeAsJSONArray", () => {
+  it("should pass plain JSON-safe arrays through unchanged", () => {
+    expect(sanitizeAsJSONArray([1, "two", { three: 3 }])).toEqual([1, "two", { three: 3 }]);
+  });
+
+  it("should drop function entries via JSON.stringify defaults", () => {
+    const sanitized = sanitizeAsJSONArray([{ ok: 1 }, Math.random]);
+    expect(sanitized).toHaveLength(2);
+    expect(sanitized[0]).toEqual({ ok: 1 });
+    expect(sanitized[1]).toBeNull();
+  });
+
+  it("should return an empty array on circular references", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(sanitizeAsJSONArray([circular])).toEqual([]);
+  });
+});
+
+describe("sanitizeAsJSONObject", () => {
+  it("should pass plain JSON-safe objects through unchanged", () => {
+    expect(sanitizeAsJSONObject({ a: 1, b: { c: "two" } })).toEqual({ a: 1, b: { c: "two" } });
+  });
+
+  it("should drop function-valued properties", () => {
+    expect(sanitizeAsJSONObject({ a: 1, fn: Math.random })).toEqual({ a: 1 });
+  });
+
+  it("should return an empty object on circular references", () => {
+    const circular: Record<string, unknown> = {};
+    circular.self = circular;
+    expect(sanitizeAsJSONObject(circular)).toEqual({});
   });
 });

--- a/src/strategy-utils.test.ts
+++ b/src/strategy-utils.test.ts
@@ -6,6 +6,7 @@ import { describe, expect, it } from "vitest";
 
 import { parseSAPPartProviderOptions } from "./sap-ai-provider-options.js";
 import {
+  buildAnthropicCacheMetadata,
   computeNoCache,
   convertToolsToSAPFormat,
   extractCompletionId,
@@ -104,6 +105,43 @@ describe("mapFinishReason", () => {
     ["GUARDRAIL_INTERVENED", "content-filter"],
   ])("should map %s to %s", (raw, unified) => {
     expect(mapFinishReason(raw)).toEqual({ raw, unified });
+  });
+});
+
+describe("buildAnthropicCacheMetadata", () => {
+  it("should return an empty fragment when token usage is null or undefined", () => {
+    expect(buildAnthropicCacheMetadata(null)).toEqual({});
+    expect(buildAnthropicCacheMetadata(undefined)).toEqual({});
+  });
+
+  it("should return an empty fragment when both ephemeral counts are zero", () => {
+    expect(
+      buildAnthropicCacheMetadata({
+        prompt_tokens: 100,
+        prompt_tokens_details: {
+          cache_creation_token_details: {
+            ephemeral_1h_input_tokens: 0,
+            ephemeral_5m_input_tokens: 0,
+          },
+        },
+      }),
+    ).toEqual({});
+  });
+
+  it("should expose cacheUsage when at least one ephemeral bucket is populated", () => {
+    expect(
+      buildAnthropicCacheMetadata({
+        prompt_tokens: 100,
+        prompt_tokens_details: {
+          cache_creation_token_details: {
+            ephemeral_1h_input_tokens: 0,
+            ephemeral_5m_input_tokens: 12,
+          },
+        },
+      }),
+    ).toEqual({
+      cacheUsage: { ephemeral_1h_input_tokens: 0, ephemeral_5m_input_tokens: 12 },
+    });
   });
 });
 

--- a/src/strategy-utils.test.ts
+++ b/src/strategy-utils.test.ts
@@ -81,6 +81,19 @@ describe("convertToolsToSAPFormat", () => {
     expect(result.tools?.[0]).not.toHaveProperty("cache_control");
     expect(sink).toHaveLength(0);
   });
+
+  it("should accept an empty options object identically to omitted options", () => {
+    const tools: LanguageModelV3FunctionTool[] = [
+      buildFunctionTool({
+        providerOptions: { "sap-ai": { cacheControl: { ttl: "5m", type: "ephemeral" } } },
+      }),
+    ];
+    const omitted = convertToolsToSAPFormat<ChatCompletionTool>(tools);
+    const empty = convertToolsToSAPFormat<ChatCompletionTool>(tools, {});
+
+    expect(empty).toEqual(omitted);
+    expect((empty.tools?.[0] as { cache_control?: unknown }).cache_control).toBeUndefined();
+  });
 });
 
 describe("mapFinishReason", () => {

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -327,6 +327,30 @@ export function applyParameterOverrides(
 }
 
 /**
+ * Builds the Anthropic prompt-caching slice of `providerMetadata[provider]`.
+ *
+ * Returns `{ cacheUsage }` when at least one ephemeral TTL bucket is populated;
+ * otherwise an empty object so the spread is a no-op.
+ * @param tokenUsage - Raw token usage from the SAP SDK response.
+ * @returns Spread-ready provider-metadata fragment.
+ * @internal
+ */
+export function buildAnthropicCacheMetadata(tokenUsage: null | SDKTokenUsage | undefined): {
+  cacheUsage?: NonNullable<
+    NonNullable<SDKTokenUsage["prompt_tokens_details"]>["cache_creation_token_details"]
+  >;
+} {
+  const details = tokenUsage?.prompt_tokens_details?.cache_creation_token_details;
+  if (
+    !details ||
+    (details.ephemeral_5m_input_tokens == null && details.ephemeral_1h_input_tokens == null)
+  ) {
+    return {};
+  }
+  return { cacheUsage: details };
+}
+
+/**
  * Builds an EmbeddingModelV3Result from embedding data.
  * @param config - Configuration with embeddings and metadata.
  * @returns Complete embedding result for AI SDK.
@@ -393,18 +417,13 @@ export function buildGenerateResult(config: GenerateResultConfig): LanguageModel
   }
 
   const intermediateFailures = response.getIntermediateFailures?.();
-  const cacheCreationTokenDetails = tokenUsage?.prompt_tokens_details?.cache_creation_token_details;
 
   return {
     content,
     finishReason,
     providerMetadata: {
       [providerName]: {
-        ...(cacheCreationTokenDetails &&
-        (cacheCreationTokenDetails.ephemeral_5m_input_tokens != null ||
-          cacheCreationTokenDetails.ephemeral_1h_input_tokens != null)
-          ? { cacheUsage: cacheCreationTokenDetails }
-          : {}),
+        ...buildAnthropicCacheMetadata(tokenUsage),
         finishReason: finishReasonRaw ?? "unknown",
         finishReasonMapped: finishReason,
         ...(intermediateFailures?.length

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -173,6 +173,7 @@ export interface GenerateResultConfig {
   readonly modelId: string;
   readonly providerName: string;
   readonly requestBody: unknown;
+  readonly requestId?: string;
   readonly response: SDKResponse;
   readonly responseHeaders: Record<string, string> | undefined;
   readonly version: string;
@@ -277,6 +278,8 @@ export interface SDKResponse {
   getTokenUsage(): SDKTokenUsage | undefined;
   getToolCalls(): null | SDKToolCall[] | undefined;
   rawResponse: { headers: Headers | Record<string, string> };
+  /** SAP-pipeline request id resolved by `extractResponseMetadata`. */
+  requestId?: string;
   responseId?: string;
 }
 
@@ -424,8 +427,16 @@ export function buildEmbeddingResult(config: EmbeddingResultConfig): EmbeddingMo
  * @internal
  */
 export function buildGenerateResult(config: GenerateResultConfig): LanguageModelV3GenerateResult {
-  const { modelId, providerName, requestBody, response, responseHeaders, version, warnings } =
-    config;
+  const {
+    modelId,
+    providerName,
+    requestBody,
+    requestId,
+    response,
+    responseHeaders,
+    version,
+    warnings,
+  } = config;
 
   const content = extractResponseContent(response);
 
@@ -469,9 +480,7 @@ export function buildGenerateResult(config: GenerateResultConfig): LanguageModel
         ...(intermediateFailures?.length
           ? { intermediateFailures: sanitizeAsJSONArray(intermediateFailures) }
           : {}),
-        ...(typeof responseHeaders?.["x-request-id"] === "string"
-          ? { requestId: responseHeaders["x-request-id"] }
-          : {}),
+        ...(requestId ? { requestId } : {}),
         version,
       },
     },
@@ -837,12 +846,13 @@ export function extractResponseContent(response: SDKResponse): LanguageModelV3Co
 }
 
 /**
- * Extracts request id and headers from an SDK response.
+ * Extracts the request id and normalised headers from an SDK response.
  *
- * Tolerates SDKs that omit `getRequestId`, expose it as a non-function, or
- * expose `headers` via a throwing accessor (the deprecated 0-arg foundation-models
- * stream constructor). The `field` parameter selects between `rawResponse`
- * (foundation-models) and `response` (orchestration).
+ * Resolves `requestId` from `getRequestId()` first; when absent, falls back to the
+ * `x-request-id` header so HTTP-only correlation surfaces remain observable.
+ * Tolerates SDKs that omit `getRequestId`, expose it as a non-function, or raise
+ * from the `headers` accessor. `field` selects the underlying HttpResponse wrapper
+ * (`rawResponse` for foundation-models, `response` for orchestration).
  * @param response - SDK response object.
  * @param field - Property containing the underlying HttpResponse wrapper.
  * @returns Combined `{ requestId, headers }` with both fields defensively gathered.
@@ -873,6 +883,10 @@ export function extractResponseMetadata(
     rawHeaders = undefined;
   }
   const headers = rawHeaders === undefined ? undefined : normalizeHeaders(rawHeaders);
+
+  if (requestId === undefined && typeof headers?.["x-request-id"] === "string") {
+    requestId = headers["x-request-id"];
+  }
 
   return { headers, requestId };
 }

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -22,6 +22,8 @@ import { TooManyEmbeddingValuesForCallError } from "@ai-sdk/provider";
 import { parseProviderOptions } from "@ai-sdk/provider-utils";
 import { z } from "zod";
 
+import type { ParsePartProviderOptions } from "./sap-ai-provider-options.js";
+
 import { deepMerge } from "./deep-merge.js";
 import { normalizeHeaders } from "./sap-ai-error.js";
 import { getProviderName, sapAIEmbeddingProviderOptions } from "./sap-ai-provider-options.js";
@@ -193,6 +195,7 @@ export type SAPResponseFormat =
  * @internal
  */
 export interface SAPTool<P = SAPToolParameters> {
+  cache_control?: { ttl?: "1h" | "5m"; type: "ephemeral" };
   function: {
     description?: string;
     name: string;
@@ -614,11 +617,13 @@ export function convertResponseFormat(
 /**
  * Converts AI SDK tools to SAP-compatible tool format.
  * @param tools - The AI SDK tools to convert.
+ * @param parsePartProviderOptions - Optional callback that reads per-tool `providerOptions['sap-ai']` (e.g. Anthropic `cacheControl`) and forwards the directive onto the SAP tool envelope. Foundation Models leaves this undefined.
  * @returns The converted tools and any warnings.
  * @internal
  */
 export function convertToolsToSAPFormat<T extends SAPTool<unknown>>(
   tools: AISDKTool[] | undefined,
+  parsePartProviderOptions?: ParsePartProviderOptions,
 ): ConvertedToolsResult<T> {
   const warnings: SharedV3Warning[] = [];
 
@@ -629,12 +634,16 @@ export function convertToolsToSAPFormat<T extends SAPTool<unknown>>(
   const convertedTools = tools
     .map((tool): null | T => {
       if (tool.type === "function") {
-        const { parameters, warning } = extractToolParameters(tool as LanguageModelV3FunctionTool);
+        const functionTool = tool as LanguageModelV3FunctionTool;
+        const { parameters, warning } = extractToolParameters(functionTool);
         if (warning) {
           warnings.push(warning);
         }
 
+        const cacheControl = parsePartProviderOptions?.(functionTool.providerOptions)?.cacheControl;
+
         return {
+          ...(cacheControl ? { cache_control: cacheControl } : {}),
           function: {
             name: tool.name,
             parameters,

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -112,6 +112,18 @@ export interface ConvertedToolsResult<T> {
 }
 
 /**
+ * Optional plumbing accepted by `convertToolsToSAPFormat`.
+ *
+ * Strategies that honour per-tool `providerOptions['sap-ai']` (e.g. orchestration
+ * Anthropic `cacheControl`) supply a `parser`; Foundation Models omits it.
+ * @internal
+ */
+export interface ConvertToolsOptions {
+  readonly parser?: ParsePartProviderOptions;
+  readonly warnings?: SharedV3Warning[];
+}
+
+/**
  * Parsed embedding provider options from AI SDK call.
  * @internal
  */
@@ -268,6 +280,15 @@ export interface SDKResponse {
   responseId?: string;
 }
 
+export {
+  createInitialStreamState,
+  createStreamTransformer,
+  StreamIdGenerator,
+  type StreamState,
+  type StreamTransformerConfig,
+  type ToolCallInProgress,
+} from "./stream-transformer.js";
+
 /**
  * @internal
  */
@@ -277,15 +298,6 @@ export interface SDKStreamChunk {
   getDeltaToolCalls(): null | SDKDeltaToolCall[] | undefined;
   getFinishReason(): null | string | undefined;
 }
-
-export {
-  createInitialStreamState,
-  createStreamTransformer,
-  StreamIdGenerator,
-  type StreamState,
-  type StreamTransformerConfig,
-  type ToolCallInProgress,
-} from "./stream-transformer.js";
 
 /**
  * Token usage shape returned by SAP AI SDK responses.
@@ -658,16 +670,19 @@ export function convertResponseFormat(
 /**
  * Converts AI SDK tools to SAP-compatible tool format.
  * @param tools - The AI SDK tools to convert.
- * @param parsePartProviderOptions - Optional callback that reads per-tool `providerOptions['sap-ai']` (e.g. Anthropic `cacheControl`) and forwards the directive onto the SAP tool envelope. Foundation Models leaves this undefined.
- * @param parserWarnings - Optional sink that receives Zod validation issues raised by the parser.
+ * @param options - Optional parser and warnings sink. The parser reads per-tool
+ * `providerOptions['sap-ai']` and forwards Anthropic `cacheControl` onto the SAP envelope;
+ * the sink receives Zod validation issues raised by the parser.
+ * @param options.parser - Reads per-tool `providerOptions['sap-ai']` and returns parsed directives (or `undefined`).
+ * @param options.warnings - Sink that collects Zod validation issues raised while parsing per-tool options.
  * @returns The converted tools and any warnings.
  * @internal
  */
 export function convertToolsToSAPFormat<T extends SAPTool<unknown>>(
   tools: AISDKTool[] | undefined,
-  parsePartProviderOptions?: ParsePartProviderOptions,
-  parserWarnings?: SharedV3Warning[],
+  options: ConvertToolsOptions = {},
 ): ConvertedToolsResult<T> {
+  const { parser, warnings: parserWarnings } = options;
   const warnings: SharedV3Warning[] = [];
 
   if (!tools || tools.length === 0) {
@@ -683,10 +698,7 @@ export function convertToolsToSAPFormat<T extends SAPTool<unknown>>(
           warnings.push(warning);
         }
 
-        const cacheControl = parsePartProviderOptions?.(
-          functionTool.providerOptions,
-          parserWarnings,
-        )?.cacheControl;
+        const cacheControl = parser?.(functionTool.providerOptions, parserWarnings)?.cacheControl;
 
         return {
           ...(cacheControl ? { cache_control: cacheControl } : {}),

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -574,6 +574,33 @@ export function buildSAPToolParameters(schema: Record<string, unknown>): SAPTool
 }
 
 /**
+ * Computes the non-cached prompt tokens from a prompt-token total and its cache slices.
+ *
+ * Returns `undefined` when the total is unknown. Returns the total unchanged when no
+ * cache breakdown is reported. Otherwise subtracts both cache buckets and clamps the
+ * result at zero to defend against inconsistent SDK token counts where
+ * `cached + cacheWrite > prompt`.
+ * @param promptTokens - Total prompt tokens reported by the SDK.
+ * @param cachedTokens - Tokens served from the prompt cache.
+ * @param cacheWriteTokens - Tokens written to the prompt cache.
+ * @returns The non-cached prompt token count, or `undefined` when unknown.
+ * @internal
+ */
+export function computeNoCache(
+  promptTokens: number | undefined,
+  cachedTokens: number | undefined,
+  cacheWriteTokens: number | undefined,
+): number | undefined {
+  if (promptTokens == null) {
+    return undefined;
+  }
+  if (cachedTokens == null && cacheWriteTokens == null) {
+    return promptTokens;
+  }
+  return Math.max(0, promptTokens - (cachedTokens ?? 0) - (cacheWriteTokens ?? 0));
+}
+
+/**
  * Converts AI SDK response format to SAP-compatible format.
  * @param optionsResponseFormat - The AI SDK response format from call options.
  * @param settingsResponseFormat - The fallback response format from settings.
@@ -913,12 +940,7 @@ export function mapTokenUsage(tokenUsage: null | SDKTokenUsage | undefined): Lan
     inputTokens: {
       cacheRead: cachedTokens,
       cacheWrite: cacheWriteTokens,
-      noCache:
-        promptTokens == null
-          ? undefined
-          : cachedTokens == null && cacheWriteTokens == null
-            ? promptTokens
-            : promptTokens - (cachedTokens ?? 0) - (cacheWriteTokens ?? 0),
+      noCache: computeNoCache(promptTokens, cachedTokens, cacheWriteTokens),
       total: promptTokens,
     },
     outputTokens: {

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -1113,19 +1113,23 @@ export async function prepareEmbeddingCall(
   return { embeddingOptions: sapOptions, providerName };
 }
 
+const jsonReplacer = (_key: string, value: unknown): unknown =>
+  typeof value === "bigint" ? value.toString() : value;
+
 /**
  * Coerces an array into a JSON-conformant payload suitable for `providerMetadata` values.
  *
  * Non-serialisable entries (functions, symbols, `undefined`) are dropped or replaced
- * by `null` per `JSON.stringify` defaults. Returns an empty array when the entire
- * payload cannot be serialised (e.g. circular references).
+ * by `null` per `JSON.stringify` defaults. Bigint values become decimal strings.
+ * Returns an empty array when the entire payload cannot be serialised (e.g. circular
+ * references).
  * @param value - Candidate array.
  * @returns JSON-safe array.
  * @internal
  */
 export function sanitizeAsJSONArray(value: readonly unknown[]): JSONArray {
   try {
-    return JSON.parse(JSON.stringify(value)) as JSONArray;
+    return JSON.parse(JSON.stringify(value, jsonReplacer)) as JSONArray;
   } catch {
     return [];
   }
@@ -1135,15 +1139,16 @@ export function sanitizeAsJSONArray(value: readonly unknown[]): JSONArray {
  * Coerces an object into a JSON-conformant payload suitable for `providerMetadata` or
  * `LanguageModelV3Usage.raw`.
  *
- * Non-serialisable values are dropped per `JSON.stringify` defaults. Returns an empty
- * object when the entire payload cannot be serialised.
+ * Non-serialisable values are dropped per `JSON.stringify` defaults. Bigint values
+ * become decimal strings. Returns an empty object when the entire payload cannot be
+ * serialised.
  * @param value - Candidate object.
  * @returns JSON-safe object.
  * @internal
  */
 export function sanitizeAsJSONObject(value: object): JSONObject {
   try {
-    return JSON.parse(JSON.stringify(value)) as JSONObject;
+    return JSON.parse(JSON.stringify(value, jsonReplacer)) as JSONObject;
   } catch {
     return {};
   }

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -112,6 +112,8 @@ export interface EmbeddingResultConfig {
   readonly embeddings: EmbeddingModelV3Embedding[];
   readonly modelId: string;
   readonly providerName: string;
+  readonly responseHeaders?: Record<string, string>;
+  readonly responseId?: string;
   readonly totalTokens: number;
   readonly version: string;
 }
@@ -326,11 +328,13 @@ export function applyParameterOverrides(
  * @internal
  */
 export function buildEmbeddingResult(config: EmbeddingResultConfig): EmbeddingModelV3Result {
-  const { embeddings, modelId, providerName, totalTokens, version } = config;
+  const { embeddings, modelId, providerName, responseHeaders, responseId, totalTokens, version } =
+    config;
 
   const providerMetadata: SharedV3ProviderMetadata = {
     [providerName]: {
       model: modelId,
+      ...(responseId ? { requestId: responseId } : {}),
       version,
     },
   };
@@ -338,6 +342,7 @@ export function buildEmbeddingResult(config: EmbeddingResultConfig): EmbeddingMo
   return {
     embeddings,
     providerMetadata,
+    ...(responseHeaders ? { response: { headers: responseHeaders } } : {}),
     usage: { tokens: totalTokens },
     warnings: [],
   };

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -139,8 +139,8 @@ export interface EmbeddingResultConfig {
   readonly embeddings: EmbeddingModelV3Embedding[];
   readonly modelId: string;
   readonly providerName: string;
+  readonly requestId?: string;
   readonly responseHeaders?: Record<string, string>;
-  readonly responseId?: string;
   readonly totalTokens: number;
   readonly version: string;
 }
@@ -403,13 +403,13 @@ export function buildAnthropicCacheMetadata(tokenUsage: null | SDKTokenUsage | u
  * @internal
  */
 export function buildEmbeddingResult(config: EmbeddingResultConfig): EmbeddingModelV3Result {
-  const { embeddings, modelId, providerName, responseHeaders, responseId, totalTokens, version } =
+  const { embeddings, modelId, providerName, requestId, responseHeaders, totalTokens, version } =
     config;
 
   const providerMetadata: SharedV3ProviderMetadata = {
     [providerName]: {
       model: modelId,
-      ...(responseId ? { requestId: responseId } : {}),
+      ...(requestId ? { requestId } : {}),
       version,
     },
   };

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -788,9 +788,6 @@ export function createAISDKRequestBodySummary(options: LanguageModelV3CallOption
  * the pipeline request id reported by `getRequestId()` when the path is not present.
  *
  * Tolerates SDKs that omit `_data` entirely or expose `getRequestId()` as a non-function.
- * Two callers: orchestration passes `["final_result","id"]`, Foundation Models passes `["id"]`.
- * Add a per-strategy extractor instead of widening the path array if a third caller needs
- * a different payload shape.
  * @param response - SDK response object exposing `_data` and optionally `getRequestId()`.
  * @param response._data - Internal SDK payload that holds the completion id under `dataPath`.
  * @param response.getRequestId - Function returning the SAP AI Core pipeline request id.
@@ -1022,11 +1019,8 @@ export function mapFinishReason(reason: null | string | undefined): LanguageMode
 /**
  * Maps SAP AI SDK token usage to Vercel AI SDK LanguageModelV3Usage.
  *
- * `usage.raw` mirrors the full SDK token-usage envelope. It is populated only when at
- * least one un-typed field is present (`prompt_tokens_details.audio_tokens`,
- * `completion_tokens_details.audio_tokens`, `accepted_prediction_tokens`, or
- * `rejected_prediction_tokens`); otherwise `raw` is omitted and consumers rely on the
- * typed `inputTokens` / `outputTokens` breakdown.
+ * `usage.raw` is populated only when the SDK reports fields not represented in
+ * `inputTokens` / `outputTokens` (audio or prediction-token buckets); otherwise omitted.
  * @param tokenUsage - Raw token usage from the SAP SDK response.
  * @returns Mapped usage with input/output token breakdowns.
  * @internal

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -387,7 +387,8 @@ export function buildAnthropicCacheMetadata(tokenUsage: null | SDKTokenUsage | u
   const details = tokenUsage?.prompt_tokens_details?.cache_creation_token_details;
   if (
     !details ||
-    (details.ephemeral_5m_input_tokens == null && details.ephemeral_1h_input_tokens == null)
+    ((details.ephemeral_5m_input_tokens ?? 0) === 0 &&
+      (details.ephemeral_1h_input_tokens ?? 0) === 0)
   ) {
     return {};
   }

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -173,6 +173,7 @@ export interface GenerateResultConfig {
   readonly modelId: string;
   readonly providerName: string;
   readonly requestBody: unknown;
+  /** SAP-pipeline request id resolved by `extractResponseMetadata`. */
   readonly requestId?: string;
   readonly response: SDKResponse;
   readonly responseHeaders: Record<string, string> | undefined;
@@ -681,11 +682,9 @@ export function convertResponseFormat(
 /**
  * Converts AI SDK tools to SAP-compatible tool format.
  * @param tools - The AI SDK tools to convert.
- * @param options - Optional parser and warnings sink. The parser reads per-tool
- * `providerOptions['sap-ai']` and forwards Anthropic `cacheControl` onto the SAP envelope;
- * the sink receives Zod validation issues raised by the parser.
- * @param options.parser - Reads per-tool `providerOptions['sap-ai']` and returns parsed directives (or `undefined`).
- * @param options.warnings - Sink that collects Zod validation issues raised while parsing per-tool options.
+ * @param options.parser - Reads per-tool `providerOptions['sap-ai']` and returns parsed directives, or `undefined` when none apply.
+ * @param options.warnings - Sink for Zod validation issues raised while parsing.
+ * @param options
  * @returns The converted tools and any warnings.
  * @internal
  */
@@ -780,9 +779,9 @@ export function createAISDKRequestBodySummary(options: LanguageModelV3CallOption
  * the pipeline request id reported by `getRequestId()` when the path is not present.
  *
  * Tolerates SDKs that omit `_data` entirely or expose `getRequestId()` as a non-function.
- * Two strategies currently call this: orchestration with `["final_result","id"]` and
- * Foundation Models with `["id"]`. Add per-strategy extractors instead of widening the
- * path-array if a third caller emerges with a different payload shape.
+ * Two callers: orchestration passes `["final_result","id"]`, Foundation Models passes `["id"]`.
+ * Add a per-strategy extractor instead of widening the path array if a third caller needs
+ * a different payload shape.
  * @param response - SDK response object exposing `_data` and optionally `getRequestId()`.
  * @param response._data - Internal SDK payload that holds the completion id under `dataPath`.
  * @param response.getRequestId - Function returning the SAP AI Core pipeline request id.
@@ -854,10 +853,9 @@ export function extractResponseContent(response: SDKResponse): LanguageModelV3Co
  * Extracts the request id and normalised headers from an SDK response.
  *
  * Resolves `requestId` from `getRequestId()` first; when absent, falls back to the
- * `x-request-id` header so HTTP-only correlation surfaces remain observable.
- * Tolerates SDKs that omit `getRequestId`, expose it as a non-function, or raise
- * from the `headers` accessor. `field` selects the underlying HttpResponse wrapper
- * (`rawResponse` for foundation-models, `response` for orchestration).
+ * `x-request-id` header. Tolerates SDKs that omit `getRequestId`, expose it as a
+ * non-function, or raise from the `headers` accessor. `field` selects the underlying
+ * HttpResponse wrapper (`rawResponse` for foundation-models, `response` for orchestration).
  * @param response - SDK response object.
  * @param field - Property containing the underlying HttpResponse wrapper.
  * @returns Combined `{ requestId, headers }` with both fields defensively gathered.

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -23,6 +23,7 @@ import { parseProviderOptions } from "@ai-sdk/provider-utils";
 import { z } from "zod";
 
 import { deepMerge } from "./deep-merge.js";
+import { normalizeHeaders } from "./sap-ai-error.js";
 import { getProviderName, sapAIEmbeddingProviderOptions } from "./sap-ai-provider-options.js";
 import { validateModelParamsWithWarnings } from "./sap-ai-provider-options.js";
 
@@ -163,6 +164,16 @@ export interface ParamMapping {
 }
 
 /**
+ * Response metadata extracted from an SDK response: server-provided request id
+ * and normalised HTTP headers.
+ * @internal
+ */
+export interface ResponseMetadata {
+  readonly headers: Record<string, string> | undefined;
+  readonly requestId: string | undefined;
+}
+
+/**
  * @internal
  */
 export type SAPResponseFormat =
@@ -276,14 +287,6 @@ export interface SDKTokenUsage {
   };
 }
 
-/**
- * @internal
- */
-export interface SDKToolCall {
-  function: { arguments: string; name: string };
-  id: string;
-}
-
 export {
   createInitialStreamState,
   createStreamTransformer,
@@ -292,6 +295,14 @@ export {
   type StreamTransformerConfig,
   type ToolCallInProgress,
 } from "./stream-transformer.js";
+
+/**
+ * @internal
+ */
+export interface SDKToolCall {
+  function: { arguments: string; name: string };
+  id: string;
+}
 
 /**
  * Applies parameter overrides from AI SDK options and modelParams.
@@ -716,6 +727,46 @@ export function extractResponseContent(response: SDKResponse): LanguageModelV3Co
   }
 
   return content;
+}
+
+/**
+ * Extracts request id and headers from an SDK response.
+ *
+ * Tolerates SDKs that omit `getRequestId`, expose it as a non-function, or
+ * expose `headers` via a throwing accessor (the deprecated 0-arg foundation-models
+ * stream constructor). The `field` parameter selects between `rawResponse`
+ * (foundation-models) and `response` (orchestration).
+ * @param response - SDK response object.
+ * @param field - Property containing the underlying HttpResponse wrapper.
+ * @returns Combined `{ requestId, headers }` with both fields defensively gathered.
+ * @internal
+ */
+export function extractResponseMetadata(
+  response: unknown,
+  field: "rawResponse" | "response",
+): ResponseMetadata {
+  let requestId: string | undefined;
+  const fn = (response as null | { getRequestId?: unknown })?.getRequestId;
+  if (typeof fn === "function") {
+    try {
+      const value = (fn as () => string | undefined).call(response);
+      requestId = typeof value === "string" && value.length > 0 ? value : undefined;
+    } catch {
+      requestId = undefined;
+    }
+  }
+
+  let headers: Record<string, string> | undefined;
+  try {
+    const wrapper = (response as null | Record<string, unknown>)?.[field] as
+      | undefined
+      | { headers?: unknown };
+    headers = wrapper ? normalizeHeaders(wrapper.headers) : undefined;
+  } catch {
+    headers = undefined;
+  }
+
+  return { headers, requestId };
 }
 
 /**

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -143,6 +143,7 @@ export interface EmbeddingResultConfig {
   readonly responseHeaders?: Record<string, string>;
   readonly totalTokens: number;
   readonly version: string;
+  readonly warnings?: readonly SharedV3Warning[];
 }
 
 /**
@@ -403,8 +404,16 @@ export function buildAnthropicCacheMetadata(tokenUsage: null | SDKTokenUsage | u
  * @internal
  */
 export function buildEmbeddingResult(config: EmbeddingResultConfig): EmbeddingModelV3Result {
-  const { embeddings, modelId, providerName, requestId, responseHeaders, totalTokens, version } =
-    config;
+  const {
+    embeddings,
+    modelId,
+    providerName,
+    requestId,
+    responseHeaders,
+    totalTokens,
+    version,
+    warnings,
+  } = config;
 
   const providerMetadata: SharedV3ProviderMetadata = {
     [providerName]: {
@@ -419,7 +428,7 @@ export function buildEmbeddingResult(config: EmbeddingResultConfig): EmbeddingMo
     providerMetadata,
     ...(responseHeaders ? { response: { headers: responseHeaders } } : {}),
     usage: { tokens: totalTokens },
-    warnings: [],
+    warnings: warnings ? [...warnings] : [],
   };
 }
 

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -372,10 +372,11 @@ export function applyParameterOverrides(
 }
 
 /**
- * Builds the Anthropic prompt-caching slice of `providerMetadata[provider]`.
+ * Returns the Anthropic prompt-caching slice of `providerMetadata[provider]` as a
+ * spread-ready fragment.
  *
  * Returns `{ cacheUsage }` when at least one ephemeral TTL bucket is populated;
- * otherwise an empty object so the spread is a no-op.
+ * otherwise `{}` so callers can `...` it unconditionally.
  * @param tokenUsage - Raw token usage from the SAP SDK response.
  * @returns Spread-ready provider-metadata fragment.
  * @internal
@@ -778,6 +779,9 @@ export function createAISDKRequestBodySummary(options: LanguageModelV3CallOption
  * the pipeline request id reported by `getRequestId()` when the path is not present.
  *
  * Tolerates SDKs that omit `_data` entirely or expose `getRequestId()` as a non-function.
+ * Today only two strategies call this: orchestration with `["final_result","id"]` and
+ * Foundation Models with `["id"]`. Add per-strategy extractors instead of widening the
+ * path-array if a third caller emerges with a different payload shape.
  * @param response - SDK response object exposing `_data` and optionally `getRequestId()`.
  * @param response._data - Internal SDK payload that holds the completion id under `dataPath`.
  * @param response.getRequestId - Function returning the SAP AI Core pipeline request id.
@@ -1009,6 +1013,12 @@ export function mapFinishReason(reason: null | string | undefined): LanguageMode
 
 /**
  * Maps SAP AI SDK token usage to Vercel AI SDK LanguageModelV3Usage.
+ *
+ * `usage.raw` mirrors the full SDK token-usage envelope. It is populated only when at
+ * least one un-typed field is present (`prompt_tokens_details.audio_tokens`,
+ * `completion_tokens_details.audio_tokens`, `accepted_prediction_tokens`, or
+ * `rejected_prediction_tokens`); otherwise `raw` is omitted and consumers rely on the
+ * typed `inputTokens` / `outputTokens` breakdown.
  * @param tokenUsage - Raw token usage from the SAP SDK response.
  * @returns Mapped usage with input/output token breakdowns.
  * @internal

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -682,9 +682,9 @@ export function convertResponseFormat(
 /**
  * Converts AI SDK tools to SAP-compatible tool format.
  * @param tools - The AI SDK tools to convert.
+ * @param options - Optional per-tool parsing config.
  * @param options.parser - Reads per-tool `providerOptions['sap-ai']` and returns parsed directives, or `undefined` when none apply.
  * @param options.warnings - Sink for Zod validation issues raised while parsing.
- * @param options
  * @returns The converted tools and any warnings.
  * @internal
  */

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -618,12 +618,14 @@ export function convertResponseFormat(
  * Converts AI SDK tools to SAP-compatible tool format.
  * @param tools - The AI SDK tools to convert.
  * @param parsePartProviderOptions - Optional callback that reads per-tool `providerOptions['sap-ai']` (e.g. Anthropic `cacheControl`) and forwards the directive onto the SAP tool envelope. Foundation Models leaves this undefined.
+ * @param parserWarnings - Optional sink that receives Zod validation issues raised by the parser.
  * @returns The converted tools and any warnings.
  * @internal
  */
 export function convertToolsToSAPFormat<T extends SAPTool<unknown>>(
   tools: AISDKTool[] | undefined,
   parsePartProviderOptions?: ParsePartProviderOptions,
+  parserWarnings?: SharedV3Warning[],
 ): ConvertedToolsResult<T> {
   const warnings: SharedV3Warning[] = [];
 
@@ -640,7 +642,10 @@ export function convertToolsToSAPFormat<T extends SAPTool<unknown>>(
           warnings.push(warning);
         }
 
-        const cacheControl = parsePartProviderOptions?.(functionTool.providerOptions)?.cacheControl;
+        const cacheControl = parsePartProviderOptions?.(
+          functionTool.providerOptions,
+          parserWarnings,
+        )?.cacheControl;
 
         return {
           ...(cacheControl ? { cache_control: cacheControl } : {}),

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -893,16 +893,19 @@ export function mapTokenUsage(tokenUsage: null | SDKTokenUsage | undefined): Lan
   const cachedTokens = tokenUsage?.prompt_tokens_details?.cached_tokens;
   const cacheWriteTokens = tokenUsage?.prompt_tokens_details?.cache_creation_tokens;
   const reasoningTokens = tokenUsage?.completion_tokens_details?.reasoning_tokens;
+  const promptTokens = tokenUsage?.prompt_tokens;
 
   return {
     inputTokens: {
       cacheRead: cachedTokens,
       cacheWrite: cacheWriteTokens,
       noCache:
-        cachedTokens != null
-          ? (tokenUsage?.prompt_tokens ?? 0) - cachedTokens
-          : tokenUsage?.prompt_tokens,
-      total: tokenUsage?.prompt_tokens,
+        promptTokens == null
+          ? undefined
+          : cachedTokens == null && cacheWriteTokens == null
+            ? promptTokens
+            : promptTokens - (cachedTokens ?? 0) - (cacheWriteTokens ?? 0),
+      total: promptTokens,
     },
     outputTokens: {
       reasoning: reasoningTokens,

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -779,7 +779,7 @@ export function createAISDKRequestBodySummary(options: LanguageModelV3CallOption
  * the pipeline request id reported by `getRequestId()` when the path is not present.
  *
  * Tolerates SDKs that omit `_data` entirely or expose `getRequestId()` as a non-function.
- * Today only two strategies call this: orchestration with `["final_result","id"]` and
+ * Two strategies currently call this: orchestration with `["final_result","id"]` and
  * Foundation Models with `["id"]`. Add per-strategy extractors instead of widening the
  * path-array if a third caller emerges with a different payload shape.
  * @param response - SDK response object exposing `_data` and optionally `getRequestId()`.

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -753,6 +753,46 @@ export function createAISDKRequestBodySummary(options: LanguageModelV3CallOption
 }
 
 /**
+ * Resolves the SDK completion identifier from an internal `_data` payload, falling back to
+ * the pipeline request id reported by `getRequestId()` when the path is not present.
+ *
+ * Tolerates SDKs that omit `_data` entirely or expose `getRequestId()` as a non-function.
+ * @param response - SDK response object exposing `_data` and optionally `getRequestId()`.
+ * @param response._data - Internal SDK payload that holds the completion id under `dataPath`.
+ * @param response.getRequestId - Function returning the SAP AI Core pipeline request id.
+ * @param dataPath - Dotted property path traversed under `_data` (e.g. `["final_result","id"]`).
+ * @returns The first non-empty completion id found along the path, or `undefined`.
+ * @internal
+ */
+export function extractCompletionId(
+  response: { _data?: unknown; getRequestId?: () => string | undefined },
+  dataPath: readonly string[],
+): string | undefined {
+  let cursor: unknown = response._data;
+  for (const key of dataPath) {
+    if (cursor !== null && typeof cursor === "object" && key in cursor) {
+      cursor = (cursor as Record<string, unknown>)[key];
+    } else {
+      cursor = undefined;
+      break;
+    }
+  }
+  if (typeof cursor === "string" && cursor.length > 0) {
+    return cursor;
+  }
+  const fn = response.getRequestId;
+  if (typeof fn !== "function") {
+    return undefined;
+  }
+  try {
+    const rid = fn.call(response);
+    return typeof rid === "string" && rid.length > 0 ? rid : undefined;
+  } catch {
+    return undefined;
+  }
+}
+
+/**
  * Extracts content (text and tool calls) from SDK response.
  * @param response - SDK response object.
  * @returns Content array for LanguageModelV3GenerateResult.
@@ -811,15 +851,16 @@ export function extractResponseMetadata(
     }
   }
 
-  let headers: Record<string, string> | undefined;
+  let rawHeaders: unknown;
   try {
     const wrapper = (response as null | Record<string, unknown>)?.[field] as
       | undefined
       | { headers?: unknown };
-    headers = wrapper ? normalizeHeaders(wrapper.headers) : undefined;
+    rawHeaders = wrapper?.headers;
   } catch {
-    headers = undefined;
+    rawHeaders = undefined;
   }
+  const headers = rawHeaders === undefined ? undefined : normalizeHeaders(rawHeaders);
 
   return { headers, requestId };
 }

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -6,6 +6,7 @@ import type {
   EmbeddingModelV3Embedding,
   EmbeddingModelV3Result,
   JSONArray,
+  JSONObject,
   LanguageModelV3CallOptions,
   LanguageModelV3Content,
   LanguageModelV3FinishReason,
@@ -47,6 +48,17 @@ export type AISDKToolChoice =
   | { type: "auto" }
   | { type: "none" }
   | { type: "required" };
+
+/**
+ * Anthropic prompt-cache breakdown surfaced via `providerMetadata['sap-ai'].cacheUsage`.
+ *
+ * Mirrors the per-TTL ephemeral bucket shape returned by the SAP AI SDK token usage
+ * payload (`prompt_tokens_details.cache_creation_token_details`).
+ * @internal
+ */
+export type AnthropicCacheUsage = NonNullable<
+  NonNullable<SDKTokenUsage["prompt_tokens_details"]>["cache_creation_token_details"]
+>;
 
 /**
  * @internal
@@ -266,6 +278,15 @@ export interface SDKStreamChunk {
   getFinishReason(): null | string | undefined;
 }
 
+export {
+  createInitialStreamState,
+  createStreamTransformer,
+  StreamIdGenerator,
+  type StreamState,
+  type StreamTransformerConfig,
+  type ToolCallInProgress,
+} from "./stream-transformer.js";
+
 /**
  * Token usage shape returned by SAP AI SDK responses.
  *
@@ -277,10 +298,14 @@ export interface SDKStreamChunk {
 export interface SDKTokenUsage {
   completion_tokens?: number;
   completion_tokens_details?: {
+    accepted_prediction_tokens?: number;
+    audio_tokens?: number;
     reasoning_tokens?: number;
+    rejected_prediction_tokens?: number;
   };
   prompt_tokens?: number;
   prompt_tokens_details?: {
+    audio_tokens?: number;
     cache_creation_token_details?: {
       ephemeral_1h_input_tokens?: number;
       ephemeral_5m_input_tokens?: number;
@@ -289,15 +314,6 @@ export interface SDKTokenUsage {
     cached_tokens?: number;
   };
 }
-
-export {
-  createInitialStreamState,
-  createStreamTransformer,
-  StreamIdGenerator,
-  type StreamState,
-  type StreamTransformerConfig,
-  type ToolCallInProgress,
-} from "./stream-transformer.js";
 
 /**
  * @internal
@@ -350,9 +366,7 @@ export function applyParameterOverrides(
  * @internal
  */
 export function buildAnthropicCacheMetadata(tokenUsage: null | SDKTokenUsage | undefined): {
-  cacheUsage?: NonNullable<
-    NonNullable<SDKTokenUsage["prompt_tokens_details"]>["cache_creation_token_details"]
-  >;
+  cacheUsage?: AnthropicCacheUsage;
 } {
   const details = tokenUsage?.prompt_tokens_details?.cache_creation_token_details;
   if (
@@ -441,7 +455,7 @@ export function buildGenerateResult(config: GenerateResultConfig): LanguageModel
         finishReason: finishReasonRaw ?? "unknown",
         finishReasonMapped: finishReason,
         ...(intermediateFailures?.length
-          ? { intermediateFailures: intermediateFailures as JSONArray }
+          ? { intermediateFailures: sanitizeAsJSONArray(intermediateFailures) }
           : {}),
         ...(typeof responseHeaders?.["x-request-id"] === "string"
           ? { requestId: responseHeaders["x-request-id"] }
@@ -938,6 +952,14 @@ export function mapTokenUsage(tokenUsage: null | SDKTokenUsage | undefined): Lan
   const reasoningTokens = tokenUsage?.completion_tokens_details?.reasoning_tokens;
   const promptTokens = tokenUsage?.prompt_tokens;
 
+  const promptDetails = tokenUsage?.prompt_tokens_details;
+  const completionDetails = tokenUsage?.completion_tokens_details;
+  const hasUnmappedFields =
+    promptDetails?.audio_tokens != null ||
+    completionDetails?.audio_tokens != null ||
+    completionDetails?.accepted_prediction_tokens != null ||
+    completionDetails?.rejected_prediction_tokens != null;
+
   return {
     inputTokens: {
       cacheRead: cachedTokens,
@@ -953,6 +975,7 @@ export function mapTokenUsage(tokenUsage: null | SDKTokenUsage | undefined): Lan
           : tokenUsage?.completion_tokens,
       total: tokenUsage?.completion_tokens,
     },
+    ...(hasUnmappedFields && tokenUsage ? { raw: sanitizeAsJSONObject(tokenUsage) } : {}),
   };
 }
 
@@ -1035,4 +1058,40 @@ export async function prepareEmbeddingCall(
   }
 
   return { embeddingOptions: sapOptions, providerName };
+}
+
+/**
+ * Coerces an array into a JSON-conformant payload suitable for `providerMetadata` values.
+ *
+ * Non-serialisable entries (functions, symbols, `undefined`) are dropped or replaced
+ * by `null` per `JSON.stringify` defaults. Returns an empty array when the entire
+ * payload cannot be serialised (e.g. circular references).
+ * @param value - Candidate array.
+ * @returns JSON-safe array.
+ * @internal
+ */
+export function sanitizeAsJSONArray(value: readonly unknown[]): JSONArray {
+  try {
+    return JSON.parse(JSON.stringify(value)) as JSONArray;
+  } catch {
+    return [];
+  }
+}
+
+/**
+ * Coerces an object into a JSON-conformant payload suitable for `providerMetadata` or
+ * `LanguageModelV3Usage.raw`.
+ *
+ * Non-serialisable values are dropped per `JSON.stringify` defaults. Returns an empty
+ * object when the entire payload cannot be serialised.
+ * @param value - Candidate object.
+ * @returns JSON-safe object.
+ * @internal
+ */
+export function sanitizeAsJSONObject(value: object): JSONObject {
+  try {
+    return JSON.parse(JSON.stringify(value)) as JSONObject;
+  } catch {
+    return {};
+  }
 }

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -267,6 +267,11 @@ export interface SDKTokenUsage {
   };
   prompt_tokens?: number;
   prompt_tokens_details?: {
+    cache_creation_token_details?: {
+      ephemeral_1h_input_tokens?: number;
+      ephemeral_5m_input_tokens?: number;
+    };
+    cache_creation_tokens?: number;
     cached_tokens?: number;
   };
 }
@@ -388,12 +393,18 @@ export function buildGenerateResult(config: GenerateResultConfig): LanguageModel
   }
 
   const intermediateFailures = response.getIntermediateFailures?.();
+  const cacheCreationTokenDetails = tokenUsage?.prompt_tokens_details?.cache_creation_token_details;
 
   return {
     content,
     finishReason,
     providerMetadata: {
       [providerName]: {
+        ...(cacheCreationTokenDetails &&
+        (cacheCreationTokenDetails.ephemeral_5m_input_tokens != null ||
+          cacheCreationTokenDetails.ephemeral_1h_input_tokens != null)
+          ? { cacheUsage: cacheCreationTokenDetails }
+          : {}),
         finishReason: finishReasonRaw ?? "unknown",
         finishReasonMapped: finishReason,
         ...(intermediateFailures?.length
@@ -810,12 +821,13 @@ export function mapFinishReason(reason: null | string | undefined): LanguageMode
  */
 export function mapTokenUsage(tokenUsage: null | SDKTokenUsage | undefined): LanguageModelV3Usage {
   const cachedTokens = tokenUsage?.prompt_tokens_details?.cached_tokens;
+  const cacheWriteTokens = tokenUsage?.prompt_tokens_details?.cache_creation_tokens;
   const reasoningTokens = tokenUsage?.completion_tokens_details?.reasoning_tokens;
 
   return {
     inputTokens: {
       cacheRead: cachedTokens,
-      cacheWrite: undefined,
+      cacheWrite: cacheWriteTokens,
       noCache:
         cachedTokens != null
           ? (tokenUsage?.prompt_tokens ?? 0) - cachedTokens

--- a/src/strategy-utils.ts
+++ b/src/strategy-utils.ts
@@ -903,6 +903,7 @@ export function mapFinishReason(reason: null | string | undefined): LanguageMode
 
   switch (reason.toLowerCase()) {
     case "content_filter":
+    case "guardrail_intervened":
       return { raw, unified: "content-filter" };
     case "end_turn":
     case "eos":
@@ -914,6 +915,7 @@ export function mapFinishReason(reason: null | string | undefined): LanguageMode
     case "function_call":
     case "tool_call":
     case "tool_calls":
+    case "tool_use":
       return { raw, unified: "tool-calls" };
     case "length":
     case "max_tokens":

--- a/src/stream-transformer.ts
+++ b/src/stream-transformer.ts
@@ -239,7 +239,8 @@ export function createStreamTransformer(
           providerMetadata: {
             [providerName]: {
               ...buildAnthropicCacheMetadata(finalUsage),
-              finishReason: streamState.finishReason.raw,
+              finishReason: streamState.finishReason.raw ?? "unknown",
+              finishReasonMapped: streamState.finishReason,
               ...(streamIntermediateFailures?.length
                 ? {
                     intermediateFailures: sanitizeAsJSONArray(streamIntermediateFailures),

--- a/src/stream-transformer.ts
+++ b/src/stream-transformer.ts
@@ -3,7 +3,6 @@
  * into Vercel AI SDK LanguageModelV3StreamPart events.
  */
 import type {
-  JSONArray,
   LanguageModelV3CallOptions,
   LanguageModelV3FinishReason,
   LanguageModelV3StreamPart,
@@ -25,6 +24,7 @@ import {
   createAISDKRequestBodySummary,
   mapFinishReason,
   mapTokenUsage,
+  sanitizeAsJSONArray,
 } from "./strategy-utils.js";
 
 /**
@@ -242,7 +242,7 @@ export function createStreamTransformer(
               finishReason: streamState.finishReason.raw,
               ...(streamIntermediateFailures?.length
                 ? {
-                    intermediateFailures: streamIntermediateFailures as JSONArray,
+                    intermediateFailures: sanitizeAsJSONArray(streamIntermediateFailures),
                   }
                 : {}),
               ...(typeof responseHeaders?.["x-request-id"] === "string"

--- a/src/stream-transformer.ts
+++ b/src/stream-transformer.ts
@@ -50,7 +50,8 @@ export interface StreamTransformerConfig {
   readonly modelId: string;
   readonly options: LanguageModelV3CallOptions;
   readonly providerName: string;
-  readonly responseHeaders?: Record<string, string>;
+  /** SAP-pipeline request id resolved by `extractResponseMetadata`. */
+  readonly requestId?: string;
   readonly responseId: string;
   readonly sdkStream: AsyncIterable<SDKStreamChunk>;
   readonly streamResponseGetCitations?: () => SDKCitation[] | undefined;
@@ -145,7 +146,7 @@ export function createStreamTransformer(
     modelId,
     options,
     providerName,
-    responseHeaders,
+    requestId,
     responseId,
     sdkStream,
     streamResponseGetCitations,
@@ -246,9 +247,7 @@ export function createStreamTransformer(
                     intermediateFailures: sanitizeAsJSONArray(streamIntermediateFailures),
                   }
                 : {}),
-              ...(typeof responseHeaders?.["x-request-id"] === "string"
-                ? { requestId: responseHeaders["x-request-id"] }
-                : {}),
+              ...(requestId ? { requestId } : {}),
               responseId,
               version,
             },

--- a/src/stream-transformer.ts
+++ b/src/stream-transformer.ts
@@ -20,7 +20,12 @@ import type {
   SDKTokenUsage,
 } from "./strategy-utils.js";
 
-import { createAISDKRequestBodySummary, mapFinishReason, mapTokenUsage } from "./strategy-utils.js";
+import {
+  buildAnthropicCacheMetadata,
+  createAISDKRequestBodySummary,
+  mapFinishReason,
+  mapTokenUsage,
+} from "./strategy-utils.js";
 
 /**
  * @internal
@@ -233,6 +238,7 @@ export function createStreamTransformer(
           finishReason: streamState.finishReason,
           providerMetadata: {
             [providerName]: {
+              ...buildAnthropicCacheMetadata(finalUsage),
               finishReason: streamState.finishReason.raw,
               ...(streamIntermediateFailures?.length
                 ? {

--- a/src/stream-transformer.ts
+++ b/src/stream-transformer.ts
@@ -215,9 +215,7 @@ export function createStreamTransformer(
 
         const finalUsage = streamResponseGetTokenUsage();
         if (finalUsage) {
-          const mapped = mapTokenUsage(finalUsage);
-          streamState.usage.inputTokens = mapped.inputTokens;
-          streamState.usage.outputTokens = mapped.outputTokens;
+          streamState.usage = mapTokenUsage(finalUsage);
         }
 
         const streamCitations = streamResponseGetCitations?.();


### PR DESCRIPTION
SDK bump `@sap-ai-sdk/orchestration` + `@sap-ai-sdk/foundation-models` 2.10 → 2.11 (#130).

Closes #71, #73, #133.

| Round | Fixed | Commits |
|---|---|---|
| Initial | 4/6 | 4 |
| Audit #1 | 16/17 | 6 |
| Audit #2 | 23/25 | 10 |
| Audit #3 | 17/17 | 10 |
| Audit #4 | 50+/5 lenses | 23 |
| Copilot review | 4/4 | 4 |

Per-finding rationale in commit messages.

`type-check + test (Node+Edge) + prettier + eslint --max-warnings 0 + lint:md (toc + mermaid) + build (V3+V2) + check-build (V3+V2)` — green, 1287 tests, 0 warning.

Deferred: #30, #31 (upstream); strategy-utils.ts split (≥1500 LOC); `hasUnmappedFields` brittleness (next SDK bump).