### PR TITLE
test: preserve signed Gemini tool call ids

### DIFF
--- a/src/convert-to-sap-messages.test.ts
+++ b/src/convert-to-sap-messages.test.ts
@@ -323,6 +323,57 @@ describe("convertToSAPMessages", () => {
       expect((result[0] as { tool_calls: unknown[] }).tool_calls).toHaveLength(2);
     });
 
+    it("should replay signed tool call ids unchanged across assistant and tool messages", () => {
+      const signedToolCallId =
+        "vertex_tool_be5b294b-ece3-46f0-8b0d-22cd00000000__sig_AY89a1_testSignature";
+
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [
+            {
+              input: { location: "Tokyo" },
+              toolCallId: signedToolCallId,
+              toolName: "get_weather",
+              type: "tool-call",
+            },
+          ],
+          role: "assistant",
+        },
+        {
+          content: [
+            {
+              output: { type: "json" as const, value: { weather: "sunny" } },
+              toolCallId: signedToolCallId,
+              toolName: "get_weather",
+              type: "tool-result",
+            },
+          ],
+          role: "tool",
+        },
+      ];
+
+      const result = convertToSAPMessages(prompt);
+      const assistantMessage = result[0] as {
+        tool_calls: {
+          extra_content?: unknown;
+          function: { arguments: string; name: string };
+          id: string;
+          thought_signature?: unknown;
+          type: string;
+        }[];
+      };
+      const toolMessage = result[1] as { tool_call_id: string };
+
+      expect(assistantMessage.tool_calls[0]).toMatchObject({
+        function: { arguments: '{"location":"Tokyo"}', name: "get_weather" },
+        id: signedToolCallId,
+        type: "function",
+      });
+      expect(assistantMessage.tool_calls[0]).not.toHaveProperty("thought_signature");
+      expect(assistantMessage.tool_calls[0]).not.toHaveProperty("extra_content");
+      expect(toolMessage.tool_call_id).toBe(signedToolCallId);
+    });
+
     it("should handle text and tool calls together", () => {
       const prompt: LanguageModelV3Prompt = [
         {

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -1567,6 +1567,67 @@ describe("SAPAILanguageModel", () => {
       });
     });
 
+    it("should preserve signed SAP Gemini tool call ids in orchestration replay requests", async () => {
+      if (api !== "orchestration") {
+        return;
+      }
+
+      const signedToolCallId =
+        "vertex_tool_be5b294b-ece3-46f0-8b0d-22cd00000000__sig_AY89a1_testSignature";
+      const model = createModelForApi("orchestration");
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [{ text: "Use the weather tool", type: "text" }],
+          role: "user",
+        },
+        {
+          content: [
+            {
+              input: { location: "Tokyo" },
+              toolCallId: signedToolCallId,
+              toolName: "get_weather",
+              type: "tool-call",
+            },
+          ],
+          role: "assistant",
+        },
+        {
+          content: [
+            {
+              output: { type: "json" as const, value: { weather: "sunny" } },
+              toolCallId: signedToolCallId,
+              toolName: "get_weather",
+              type: "tool-result",
+            },
+          ],
+          role: "tool",
+        },
+      ];
+
+      await model.doGenerate({ prompt });
+
+      const request = await getLastOrchRequest();
+      expect(request.messages).toEqual([
+        { content: "Use the weather tool", role: "user" },
+        {
+          content: "",
+          role: "assistant",
+          tool_calls: [
+            {
+              function: { arguments: '{"location":"Tokyo"}', name: "get_weather" },
+              id: signedToolCallId,
+              type: "function",
+            },
+          ],
+        },
+        {
+          content: '{"type":"json","value":{"weather":"sunny"}}',
+          role: "tool",
+          tool_call_id: signedToolCallId,
+        },
+      ]);
+    });
+
     it.each([
       {
         description: "normalize array header values",

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -1567,67 +1567,6 @@ describe("SAPAILanguageModel", () => {
       });
     });
 
-    it("should preserve signed SAP Gemini tool call ids in orchestration replay requests", async () => {
-      if (api !== "orchestration") {
-        return;
-      }
-
-      const signedToolCallId =
-        "vertex_tool_be5b294b-ece3-46f0-8b0d-22cd00000000__sig_AY89a1_testSignature";
-      const model = createModelForApi("orchestration");
-      const prompt: LanguageModelV3Prompt = [
-        {
-          content: [{ text: "Use the weather tool", type: "text" }],
-          role: "user",
-        },
-        {
-          content: [
-            {
-              input: { location: "Tokyo" },
-              toolCallId: signedToolCallId,
-              toolName: "get_weather",
-              type: "tool-call",
-            },
-          ],
-          role: "assistant",
-        },
-        {
-          content: [
-            {
-              output: { type: "json" as const, value: { weather: "sunny" } },
-              toolCallId: signedToolCallId,
-              toolName: "get_weather",
-              type: "tool-result",
-            },
-          ],
-          role: "tool",
-        },
-      ];
-
-      await model.doGenerate({ prompt });
-
-      const request = await getLastOrchRequest();
-      expect(request.messages).toEqual([
-        { content: "Use the weather tool", role: "user" },
-        {
-          content: "",
-          role: "assistant",
-          tool_calls: [
-            {
-              function: { arguments: '{"location":"Tokyo"}', name: "get_weather" },
-              id: signedToolCallId,
-              type: "function",
-            },
-          ],
-        },
-        {
-          content: '{"type":"json","value":{"weather":"sunny"}}',
-          role: "tool",
-          tool_call_id: signedToolCallId,
-        },
-      ]);
-    });
-
     it.each([
       {
         description: "normalize array header values",
@@ -3232,6 +3171,69 @@ describe("SAPAILanguageModel", () => {
       const responseMetadata = parts.find((p) => p.type === "response-metadata");
       expect(responseMetadata).toBeDefined();
       expect((responseMetadata as { id: string }).id).toBe("fm-no-headers-req-id");
+    });
+  });
+
+  describe("doGenerate replay requests (orchestration API)", () => {
+    beforeEach(async () => {
+      await resetMockStateForApi("orchestration");
+    });
+
+    it("should preserve signed SAP Gemini tool call ids in orchestration replay requests", async () => {
+      const signedToolCallId =
+        "vertex_tool_be5b294b-ece3-46f0-8b0d-22cd00000000__sig_AY89a1_testSignature";
+      const model = createModelForApi("orchestration");
+      const prompt: LanguageModelV3Prompt = [
+        {
+          content: [{ text: "Use the weather tool", type: "text" }],
+          role: "user",
+        },
+        {
+          content: [
+            {
+              input: { location: "Tokyo" },
+              toolCallId: signedToolCallId,
+              toolName: "get_weather",
+              type: "tool-call",
+            },
+          ],
+          role: "assistant",
+        },
+        {
+          content: [
+            {
+              output: { type: "json" as const, value: { weather: "sunny" } },
+              toolCallId: signedToolCallId,
+              toolName: "get_weather",
+              type: "tool-result",
+            },
+          ],
+          role: "tool",
+        },
+      ];
+
+      await model.doGenerate({ prompt });
+
+      const request = await getLastOrchRequest();
+      expect(request.messages).toEqual([
+        { content: "Use the weather tool", role: "user" },
+        {
+          content: "",
+          role: "assistant",
+          tool_calls: [
+            {
+              function: { arguments: '{"location":"Tokyo"}', name: "get_weather" },
+              id: signedToolCallId,
+              type: "function",
+            },
+          ],
+        },
+        {
+          content: '{"type":"json","value":{"weather":"sunny"}}',
+          role: "tool",
+          tool_call_id: signedToolCallId,
+        },
+      ]);
     });
   });
 

--- a/src/strategy-utils.test.ts
+++ b/src/strategy-utils.test.ts
@@ -10,10 +10,12 @@ import {
   computeNoCache,
   convertToolsToSAPFormat,
   extractCompletionId,
+  extractResponseContent,
   mapFinishReason,
   sanitizeAsJSONArray,
   sanitizeAsJSONObject,
   type SAPTool,
+  type SDKResponse,
 } from "./strategy-utils.js";
 
 interface ChatCompletionTool extends SAPTool<unknown> {
@@ -242,6 +244,38 @@ describe("extractCompletionId", () => {
         path,
       ),
     ).toBe(expected);
+  });
+});
+
+describe("extractResponseContent", () => {
+  it("should preserve SAP's Gemini thought signature in the tool-call id suffix", () => {
+    const signedToolCallId =
+      "vertex_tool_be5b294b-ece3-46f0-8b0d-22cd00000000__sig_AY89a1_testSignature";
+
+    const response: SDKResponse = {
+      getContent: () => undefined,
+      getFinishReason: () => undefined,
+      getTokenUsage: () => undefined,
+      getToolCalls: () => [
+        {
+          function: {
+            arguments: "{}",
+            name: "lookup",
+          },
+          id: signedToolCallId,
+        },
+      ],
+      rawResponse: { headers: new Headers() },
+    };
+
+    const [toolCall] = extractResponseContent(response);
+
+    expect(toolCall).toEqual(
+      expect.objectContaining({
+        toolCallId: signedToolCallId,
+        type: "tool-call",
+      }),
+    );
   });
 });
 


### PR DESCRIPTION
## Summary
- add regression coverage for SAP Gemini signed tool-call IDs that include the opaque `__sig_...` suffix
- verify response extraction keeps the full signed ID as `toolCallId`
- verify assistant/tool replay conversion and orchestration request building send the signed ID back unchanged
- avoid speculative wire fields such as `thought_signature` or `extra_content` because SAP runtime evidence showed the signature is encoded in the ID itself

Refs #161.

## Runtime Evidence
- SAP Orchestration response exposes signed Gemini tool calls as IDs like `vertex_tool_<uuid>__sig_<signature>`
- replay with the full signed ID succeeds
- replay after stripping the `__sig_...` suffix fails with `Function call is missing a thought_signature in functionCall parts`
- no separate `thought_signature`, `thoughtSignature`, or `extra_content` field was exposed by the SAP SDK runtime response

## Validation
- `npm run type-check`
- `npm run test`
- `npm run test:node`
- `npm run test:edge`
- `npm run prettier-check`
- `npm run lint`
- `npm run build && npm run check-build`
- `npm run build:v2 && npm run check-build:v2`
- `GIT_MASTER=1 git diff --check`
- pre-push hook: `npm run type-check` and `npm run test`
