### PR TITLE
docs: address remaining requestConfig review follow-ups

### DIFF
--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1105,6 +1105,40 @@ const provider = createSAPAIProvider({
 });
 ```
 
+**Example with a custom request timeout:**
+
+```typescript
+const provider = createSAPAIProvider({
+  requestConfig: {
+    timeout: 30_000, // 30 seconds
+  },
+});
+```
+
+**Notes on `requestConfig`:**
+
+- **Provider-level only.** `requestConfig` is applied to every call from this provider
+  and is not currently overridable per-call via `providerOptions['sap-ai']`. For
+  per-request variation (e.g. different `AI-Object-Store-Secret-Name` per tenant),
+  create separate provider instances.
+- **Runtime portability.** `httpAgent`, `httpsAgent`, `proxy`, and `adapter` are
+  Node-only and are silently ignored on Edge / Cloudflare Workers runtimes. Prefer
+  `headers`, `params`, and `timeout` for portable configuration.
+- **Abort semantics.** The AI SDK `abortSignal` option always wins over any `signal`
+  set on `requestConfig`; the latter is dropped before the request is forwarded.
+- **SAP AI Core `AI-*` headers.** `requestConfig.headers` accepts SAP-specific
+  headers that alter server-side behaviour:
+  - **`AI-Object-Store-Secret-Name`** — _feedback service only._ Names the
+    pre-registered object store secret used by the SAP AI Core Orchestration Service
+    to write inference feedback / observability data. Omit if you are not using the
+    feedback service.
+  - **`AI-Resource-Group`** — scopes the request to a resource group. Prefer the
+    `resourceGroup` provider option; pass this header only when you need a
+    per-request override.
+
+  These headers are SAP AI Core product-specific. Source: SAP AI SDK JS
+  [`orchestration-types.ts`](https://github.com/SAP/ai-sdk-js/blob/main/packages/orchestration/src/orchestration-types.ts).
+
 **Example with provider name:**
 
 ```typescript

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1065,17 +1065,17 @@ Configuration options for the SAP AI Provider.
 
 **Properties:**
 
-| Property                | Type                                     | Default           | Description                                                                                                                                                                         |
-| ----------------------- | ---------------------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                  | `string`                                 | `'sap-ai'`        | Provider name used as key in `providerOptions`/`providerMetadata`. Provider identifier uses `{name}.{type}` format (e.g., `"sap-ai.chat"`)                                          |
-| `api`                   | `'orchestration' \| 'foundation-models'` | `'orchestration'` | SAP AI Core API to use. Orchestration provides full features (masking, filtering, grounding); Foundation Models provides direct model access                                        |
-| `resourceGroup`         | `string`                                 | `'default'`       | SAP AI Core resource group                                                                                                                                                          |
-| `deploymentId`          | `string`                                 | Auto              | SAP AI Core deployment ID                                                                                                                                                           |
-| `destination`           | `HttpDestinationOrFetchOptions`          | -                 | Custom destination configuration                                                                                                                                                    |
-| `requestConfig`         | `CustomRequestConfig`                    | -                 | Custom HTTP request configuration forwarded on every call. See the "Note on `requestConfig`" below for scope, portability, abort semantics, and SAP AI Core `AI-*` header guidance. |
-| `defaultSettings`       | `SAPAISettings`                          | -                 | Default model settings applied to all models                                                                                                                                        |
-| `logLevel`              | `'debug' \| 'error' \| 'info' \| 'warn'` | `'warn'`          | Log level for SAP Cloud SDK internal logging (authentication, service binding). Can be overridden via `SAP_CLOUD_SDK_LOG_LEVEL` environment variable                                |
-| `warnOnAmbiguousConfig` | `boolean`                                | `true`            | Emit warnings for ambiguous configurations (e.g., when both `deploymentId` and `resourceGroup` are provided, `deploymentId` wins)                                                   |
+| Property                | Type                                     | Default           | Description                                                                                                                                                                                          |
+| ----------------------- | ---------------------------------------- | ----------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                  | `string`                                 | `'sap-ai'`        | Provider name used as key in `providerOptions`/`providerMetadata`. Provider identifier uses `{name}.{type}` format (e.g., `"sap-ai.chat"`)                                                           |
+| `api`                   | `'orchestration' \| 'foundation-models'` | `'orchestration'` | SAP AI Core API to use. Orchestration provides full features (masking, filtering, grounding); Foundation Models provides direct model access                                                         |
+| `resourceGroup`         | `string`                                 | `'default'`       | SAP AI Core resource group                                                                                                                                                                           |
+| `deploymentId`          | `string`                                 | Auto              | SAP AI Core deployment ID                                                                                                                                                                            |
+| `destination`           | `HttpDestinationOrFetchOptions`          | -                 | Custom destination configuration                                                                                                                                                                     |
+| `requestConfig`         | `CustomRequestConfig`                    | -                 | Custom HTTP request configuration forwarded on every call. See [Note on `requestConfig`](#requestconfig-note) below for scope, portability, abort semantics, and SAP AI Core `AI-*` header guidance. |
+| `defaultSettings`       | `SAPAISettings`                          | -                 | Default model settings applied to all models                                                                                                                                                         |
+| `logLevel`              | `'debug' \| 'error' \| 'info' \| 'warn'` | `'warn'`          | Log level for SAP Cloud SDK internal logging (authentication, service binding). Can be overridden via `SAP_CLOUD_SDK_LOG_LEVEL` environment variable                                                 |
+| `warnOnAmbiguousConfig` | `boolean`                                | `true`            | Emit warnings for ambiguous configurations (e.g., when both `deploymentId` and `resourceGroup` are provided, `deploymentId` wins)                                                                    |
 
 **Example:**
 
@@ -1094,7 +1094,9 @@ const settings: SAPAIProviderSettings = {
 };
 ```
 
-> **Note on `requestConfig`:**
+<a id="requestconfig-note"></a>
+
+> **Note:**
 >
 > - **Provider-level scope only.** `requestConfig` is applied to every call from this
 >   provider and is not currently overridable per-call via `providerOptions['sap-ai']`.
@@ -1112,12 +1114,14 @@ const settings: SAPAIProviderSettings = {
 >   headers that alter server-side behaviour:
 >   - **`AI-Object-Store-Secret-Name`** — names the object store secret used by the
 >     feedback service. Omit if you are not using the feedback service.
->   - **`AI-Resource-Group`** — **not settable via `requestConfig.headers`**. The SAP
->     AI SDK types this header as `never` in `OrchestrationRequestHeaders`, so
->     attempting to set it via `requestConfig.headers` is a TypeScript error. Use the
->     `resourceGroup` provider option or `deploymentConfig` instead.
+>   - **`AI-Resource-Group`** — **not a supported override on `requestConfig.headers`**.
+>     The SAP AI SDK types this header as `never` on its internal
+>     `OrchestrationRequestHeaders` type, but that constraint does not flow through
+>     `CustomRequestConfig.headers` (typed as `Record<string, any>`), so TypeScript
+>     will not flag the assignment. Use the `resourceGroup` provider option or
+>     `deploymentConfig` instead.
 >
-> Source: SAP AI SDK JS [`orchestration-types.ts`](https://github.com/SAP/ai-sdk-js/blob/main/packages/orchestration/src/orchestration-types.ts).
+> Source: SAP AI SDK [`orchestration-types.ts`](https://github.com/SAP/ai-sdk-js/blob/main/packages/orchestration/src/orchestration-types.ts).
 
 **Example with custom request headers:**
 

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1065,17 +1065,17 @@ Configuration options for the SAP AI Provider.
 
 **Properties:**
 
-| Property                | Type                                     | Default           | Description                                                                                                                                                                                                                                                                           |
-| ----------------------- | ---------------------------------------- | ----------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `name`                  | `string`                                 | `'sap-ai'`        | Provider name used as key in `providerOptions`/`providerMetadata`. Provider identifier uses `{name}.{type}` format (e.g., `"sap-ai.chat"`)                                                                                                                                            |
-| `api`                   | `'orchestration' \| 'foundation-models'` | `'orchestration'` | SAP AI Core API to use. Orchestration provides full features (masking, filtering, grounding); Foundation Models provides direct model access                                                                                                                                          |
-| `resourceGroup`         | `string`                                 | `'default'`       | SAP AI Core resource group                                                                                                                                                                                                                                                            |
-| `deploymentId`          | `string`                                 | Auto              | SAP AI Core deployment ID                                                                                                                                                                                                                                                             |
-| `destination`           | `HttpDestinationOrFetchOptions`          | -                 | Custom destination configuration                                                                                                                                                                                                                                                      |
-| `requestConfig`         | `CustomRequestConfig`                    | -                 | Custom request configuration forwarded to the underlying SAP AI SDK client on every call. Use `requestConfig.headers` to pass service-specific HTTP headers (e.g. `AI-Object-Store-Secret-Name`). The `signal` property is ignored here — use the AI SDK `abortSignal` option instead |
-| `defaultSettings`       | `SAPAISettings`                          | -                 | Default model settings applied to all models                                                                                                                                                                                                                                          |
-| `logLevel`              | `'debug' \| 'error' \| 'info' \| 'warn'` | `'warn'`          | Log level for SAP Cloud SDK internal logging (authentication, service binding). Can be overridden via `SAP_CLOUD_SDK_LOG_LEVEL` environment variable                                                                                                                                  |
-| `warnOnAmbiguousConfig` | `boolean`                                | `true`            | Emit warnings for ambiguous configurations (e.g., when both `deploymentId` and `resourceGroup` are provided, `deploymentId` wins)                                                                                                                                                     |
+| Property                | Type                                     | Default           | Description                                                                                                                                                                         |
+| ----------------------- | ---------------------------------------- | ----------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `name`                  | `string`                                 | `'sap-ai'`        | Provider name used as key in `providerOptions`/`providerMetadata`. Provider identifier uses `{name}.{type}` format (e.g., `"sap-ai.chat"`)                                          |
+| `api`                   | `'orchestration' \| 'foundation-models'` | `'orchestration'` | SAP AI Core API to use. Orchestration provides full features (masking, filtering, grounding); Foundation Models provides direct model access                                        |
+| `resourceGroup`         | `string`                                 | `'default'`       | SAP AI Core resource group                                                                                                                                                          |
+| `deploymentId`          | `string`                                 | Auto              | SAP AI Core deployment ID                                                                                                                                                           |
+| `destination`           | `HttpDestinationOrFetchOptions`          | -                 | Custom destination configuration                                                                                                                                                    |
+| `requestConfig`         | `CustomRequestConfig`                    | -                 | Custom HTTP request configuration forwarded on every call. See the "Note on `requestConfig`" below for scope, portability, abort semantics, and SAP AI Core `AI-*` header guidance. |
+| `defaultSettings`       | `SAPAISettings`                          | -                 | Default model settings applied to all models                                                                                                                                        |
+| `logLevel`              | `'debug' \| 'error' \| 'info' \| 'warn'` | `'warn'`          | Log level for SAP Cloud SDK internal logging (authentication, service binding). Can be overridden via `SAP_CLOUD_SDK_LOG_LEVEL` environment variable                                |
+| `warnOnAmbiguousConfig` | `boolean`                                | `true`            | Emit warnings for ambiguous configurations (e.g., when both `deploymentId` and `resourceGroup` are provided, `deploymentId` wins)                                                   |
 
 **Example:**
 
@@ -1093,6 +1093,31 @@ const settings: SAPAIProviderSettings = {
   },
 };
 ```
+
+> **Note on `requestConfig`:**
+>
+> - **Provider-level scope only.** `requestConfig` is applied to every call from this
+>   provider and is not currently overridable per-call via `providerOptions['sap-ai']`.
+>   For per-request variation (e.g. different `AI-Object-Store-Secret-Name` per tenant),
+>   create separate provider instances.
+> - **Runtime portability.** `httpAgent` and `httpsAgent` are Node-only and are silently
+>   ignored on Edge / Cloudflare Workers runtimes. Prefer `headers`, `params`, and
+>   `timeout` for portable configuration. (`timeout` reaches axios via the
+>   `CustomRequestConfig` `Record<string, any>` index signature; it is honoured
+>   end-to-end but is not a first-class typed field.)
+> - **Abort semantics.** The AI SDK `abortSignal` option always wins over any `signal`
+>   set on `requestConfig`; the latter is dropped before the request is forwarded via
+>   the internal `mergeRequestConfig` helper.
+> - **SAP AI Core `AI-*` headers.** `requestConfig.headers` accepts service-specific
+>   headers that alter server-side behaviour:
+>   - **`AI-Object-Store-Secret-Name`** — names the object store secret used by the
+>     feedback service. Omit if you are not using the feedback service.
+>   - **`AI-Resource-Group`** — **not settable via `requestConfig.headers`**. The SAP
+>     AI SDK types this header as `never` in `OrchestrationRequestHeaders`, so
+>     attempting to set it via `requestConfig.headers` is a TypeScript error. Use the
+>     `resourceGroup` provider option or `deploymentConfig` instead.
+>
+> Source: SAP AI SDK JS [`orchestration-types.ts`](https://github.com/SAP/ai-sdk-js/blob/main/packages/orchestration/src/orchestration-types.ts).
 
 **Example with custom request headers:**
 
@@ -1114,30 +1139,6 @@ const provider = createSAPAIProvider({
   },
 });
 ```
-
-**Notes on `requestConfig`:**
-
-- **Provider-level only.** `requestConfig` is applied to every call from this provider
-  and is not currently overridable per-call via `providerOptions['sap-ai']`. For
-  per-request variation (e.g. different `AI-Object-Store-Secret-Name` per tenant),
-  create separate provider instances.
-- **Runtime portability.** `httpAgent`, `httpsAgent`, `proxy`, and `adapter` are
-  Node-only and are silently ignored on Edge / Cloudflare Workers runtimes. Prefer
-  `headers`, `params`, and `timeout` for portable configuration.
-- **Abort semantics.** The AI SDK `abortSignal` option always wins over any `signal`
-  set on `requestConfig`; the latter is dropped before the request is forwarded.
-- **SAP AI Core `AI-*` headers.** `requestConfig.headers` accepts SAP-specific
-  headers that alter server-side behaviour:
-  - **`AI-Object-Store-Secret-Name`** — _feedback service only._ Names the
-    pre-registered object store secret used by the SAP AI Core Orchestration Service
-    to write inference feedback / observability data. Omit if you are not using the
-    feedback service.
-  - **`AI-Resource-Group`** — scopes the request to a resource group. Prefer the
-    `resourceGroup` provider option; pass this header only when you need a
-    per-request override.
-
-  These headers are SAP AI Core product-specific. Source: SAP AI SDK JS
-  [`orchestration-types.ts`](https://github.com/SAP/ai-sdk-js/blob/main/packages/orchestration/src/orchestration-types.ts).
 
 **Example with provider name:**
 

--- a/API_REFERENCE.md
+++ b/API_REFERENCE.md
@@ -1114,7 +1114,7 @@ const settings: SAPAIProviderSettings = {
 >   headers that alter server-side behaviour:
 >   - **`AI-Object-Store-Secret-Name`** — names the object store secret used by the
 >     feedback service. Omit if you are not using the feedback service.
->   - **`AI-Resource-Group`** — **not a supported override on `requestConfig.headers`**.
+>   - **`AI-Resource-Group`** — **do not set via `requestConfig.headers`**.
 >     The SAP AI SDK types this header as `never` on its internal
 >     `OrchestrationRequestHeaders` type, but that constraint does not flow through
 >     `CustomRequestConfig.headers` (typed as `Record<string, any>`), so TypeScript

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -702,13 +702,18 @@ per-call `abortSignal` is merged with the provider-level `requestConfig` (see
 via the internal `mergeRequestConfig` helper. Any `signal` present on
 `requestConfig` is dropped so the AI SDK `abortSignal` always wins.
 
-**Non-streaming:**
+The snippets below show the **Orchestration** call sites. The **Foundation Models**
+path uses `client.run()` for non-streaming and a 3-argument
+`client.stream(request, abortSignal, requestConfig)` for streaming; the same
+`mergeRequestConfig` helper is applied in both cases.
+
+**Non-streaming (Orchestration):**
 
 ```typescript
 const response = await client.chatCompletion(request, mergeRequestConfig(requestConfig, abortSignal));
 ```
 
-**Streaming:**
+**Streaming (Orchestration):**
 
 ```typescript
 const stream = await client.stream(request, abortSignal, streamOptions, mergeRequestConfig(requestConfig, undefined));

--- a/ARCHITECTURE.md
+++ b/ARCHITECTURE.md
@@ -696,21 +696,27 @@ modules: {
 
 ### Request Cancellation
 
-The provider supports HTTP-level request cancellation via `AbortSignal`.
+The provider supports HTTP-level request cancellation via `AbortSignal`. The
+per-call `abortSignal` is merged with the provider-level `requestConfig` (see
+[`SAPAIProviderSettings.requestConfig`](./API_REFERENCE.md#sapaiprovidersettings))
+via the internal `mergeRequestConfig` helper. Any `signal` present on
+`requestConfig` is dropped so the AI SDK `abortSignal` always wins.
 
 **Non-streaming:**
 
 ```typescript
-const response = await client.chatCompletion(requestBody, options.abortSignal ? { signal: options.abortSignal } : undefined);
+const response = await client.chatCompletion(request, mergeRequestConfig(requestConfig, abortSignal));
 ```
 
 **Streaming:**
 
 ```typescript
-const stream = await client.stream(requestBody, options.abortSignal, streamOptions, requestConfig);
+const stream = await client.stream(request, abortSignal, streamOptions, mergeRequestConfig(requestConfig, undefined));
 ```
 
-The signal passes through `requestConfig` to the SAP AI SDK, which forwards it to the underlying Axios HTTP client. When aborted, the HTTP connection is closed and server-side processing stops.
+The signal is forwarded to the SAP AI SDK, which passes it to the underlying
+Axios HTTP client. When aborted, the HTTP connection is closed and server-side
+processing stops.
 
 ### Tool Calling Flow
 

--- a/README.md
+++ b/README.md
@@ -648,8 +648,11 @@ authentication, model parameters, data masking, content filtering, and more.
   `providerOptions`/`providerMetadata`.
 - `resourceGroup`: SAP AI Core resource group (default: 'default')
 - `deploymentId`: Specific deployment ID (auto-resolved if not set)
-- `requestConfig`: Custom HTTP request configuration (headers, params, etc.) forwarded
-  to the underlying SAP AI SDK client on every call
+- `requestConfig`: Custom HTTP request configuration (headers, params, timeout, etc.)
+  forwarded to the underlying SAP AI SDK client on every call. Provider-level scope
+  only; use `requestConfig.headers` for SAP-specific headers such as
+  `AI-Object-Store-Secret-Name` (feedback service). See
+  [API Reference](./API_REFERENCE.md#sapaiprovidersettings) for portability caveats.
 - `modelParams`: Temperature, maxTokens, topP, and other generation parameters
 - `masking`: SAP Data Privacy Integration (DPI) configuration
 - `filtering`: Content safety filters (Azure Content Safety, Llama Guard)

--- a/src/index-v2.ts
+++ b/src/index-v2.ts
@@ -173,7 +173,9 @@ export { VERSION } from "./version.js";
  * SAP AI SDK request configuration type for {@link SAPAIProviderSettings.requestConfig}.
  *
  * Re-exported so consumers can type provider options without a direct dependency on
- * `@sap-ai-sdk/core`.
+ * `@sap-ai-sdk/core`. The shape tracks `@sap-ai-sdk/core` versioning and is inherited
+ * transitively; upstream changes to `CustomRequestConfig` propagate here without a
+ * release of this package.
  */
 export type { CustomRequestConfig } from "@sap-ai-sdk/core";
 
@@ -188,3 +190,12 @@ export type { OrchestrationErrorResponse } from "@sap-ai-sdk/orchestration";
  * For advanced users who need to use the SAP AI SDK directly.
  */
 export { OrchestrationClient, OrchestrationEmbeddingClient } from "@sap-ai-sdk/orchestration";
+
+/**
+ * SAP Cloud SDK destination type for {@link SAPAIProviderSettings.destination}.
+ *
+ * Re-exported so consumers can type provider options without a direct dependency on
+ * `@sap-cloud-sdk/connectivity`. The shape tracks `@sap-cloud-sdk/connectivity`
+ * versioning and is inherited transitively.
+ */
+export type { HttpDestinationOrFetchOptions } from "@sap-cloud-sdk/connectivity";

--- a/src/index-v2.ts
+++ b/src/index-v2.ts
@@ -170,6 +170,14 @@ export { resolveApi, validateSettings } from "./sap-ai-validation.js";
 export { VERSION } from "./version.js";
 
 /**
+ * SAP AI SDK request configuration type for {@link SAPAIProviderSettings.requestConfig}.
+ *
+ * Re-exported so consumers can type provider options without a direct dependency on
+ * `@sap-ai-sdk/core`.
+ */
+export type { CustomRequestConfig } from "@sap-ai-sdk/core";
+
+/**
  * Error handling types and classes for SAP AI Core error responses.
  */
 export type { OrchestrationErrorResponse } from "@sap-ai-sdk/orchestration";

--- a/src/index.ts
+++ b/src/index.ts
@@ -162,7 +162,9 @@ export { VERSION } from "./version.js";
  * SAP AI SDK request configuration type for {@link SAPAIProviderSettings.requestConfig}.
  *
  * Re-exported so consumers can type provider options without a direct dependency on
- * `@sap-ai-sdk/core`.
+ * `@sap-ai-sdk/core`. The shape tracks `@sap-ai-sdk/core` versioning and is inherited
+ * transitively; upstream changes to `CustomRequestConfig` propagate here without a
+ * release of this package.
  */
 export type { CustomRequestConfig } from "@sap-ai-sdk/core";
 
@@ -177,3 +179,12 @@ export type { OrchestrationErrorResponse } from "@sap-ai-sdk/orchestration";
  * For advanced users who need to use the SAP AI SDK directly.
  */
 export { OrchestrationClient, OrchestrationEmbeddingClient } from "@sap-ai-sdk/orchestration";
+
+/**
+ * SAP Cloud SDK destination type for {@link SAPAIProviderSettings.destination}.
+ *
+ * Re-exported so consumers can type provider options without a direct dependency on
+ * `@sap-cloud-sdk/connectivity`. The shape tracks `@sap-cloud-sdk/connectivity`
+ * versioning and is inherited transitively.
+ */
+export type { HttpDestinationOrFetchOptions } from "@sap-cloud-sdk/connectivity";

--- a/src/index.ts
+++ b/src/index.ts
@@ -159,6 +159,14 @@ export { resolveApi, validateSettings } from "./sap-ai-validation.js";
 export { VERSION } from "./version.js";
 
 /**
+ * SAP AI SDK request configuration type for {@link SAPAIProviderSettings.requestConfig}.
+ *
+ * Re-exported so consumers can type provider options without a direct dependency on
+ * `@sap-ai-sdk/core`.
+ */
+export type { CustomRequestConfig } from "@sap-ai-sdk/core";
+
+/**
  * Error handling types and classes for SAP AI Core error responses.
  */
 export type { OrchestrationErrorResponse } from "@sap-ai-sdk/orchestration";

--- a/src/sap-ai-embedding-model.test.ts
+++ b/src/sap-ai-embedding-model.test.ts
@@ -9,6 +9,7 @@ import { clearStrategyCaches } from "./sap-ai-strategy.js";
 type APIType = "foundation-models" | "orchestration";
 
 interface CapturedRequestConfig {
+  [key: string]: unknown;
   headers?: Record<string, string>;
   signal?: AbortSignal;
 }

--- a/src/sap-ai-embedding-model.test.ts
+++ b/src/sap-ai-embedding-model.test.ts
@@ -8,6 +8,11 @@ import { clearStrategyCaches } from "./sap-ai-strategy.js";
 
 type APIType = "foundation-models" | "orchestration";
 
+interface CapturedRequestConfig {
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+}
+
 const EMBED_REQUEST_IDS = {
   "foundation-models": "test-fm-embed-request-id",
   orchestration: "test-orch-embed-request-id",
@@ -26,7 +31,7 @@ interface FMEmbedCall {
     input_type?: string;
     user?: string;
   };
-  requestConfig?: { signal?: AbortSignal };
+  requestConfig?: CapturedRequestConfig;
 }
 interface FMEmbeddingResponse {
   _data: {
@@ -47,7 +52,7 @@ interface OrchestrationConstructorCall {
 }
 interface OrchestrationEmbedCall {
   request: { input: string[]; type?: string };
-  requestConfig?: { signal?: AbortSignal };
+  requestConfig?: CapturedRequestConfig;
 }
 interface OrchestrationEmbeddingResponse {
   getEmbeddings: () => { embedding: number[] | string; index: number; object: string }[];
@@ -66,7 +71,7 @@ vi.mock("@sap-ai-sdk/orchestration", () => {
     embed = vi
       .fn()
       .mockImplementation(
-        (request: { input: string[]; type?: string }, requestConfig?: { signal?: AbortSignal }) => {
+        (request: { input: string[]; type?: string }, requestConfig?: CapturedRequestConfig) => {
           MockOrchestrationEmbeddingClient.lastEmbedCall = { request, requestConfig };
           const errorToThrow = MockOrchestrationEmbeddingClient.embedError;
           if (errorToThrow) {
@@ -125,7 +130,7 @@ vi.mock("@sap-ai-sdk/foundation-models", () => {
     run = vi
       .fn()
       .mockImplementation(
-        (request: FMEmbedCall["request"], requestConfig?: { signal?: AbortSignal }) => {
+        (request: FMEmbedCall["request"], requestConfig?: CapturedRequestConfig) => {
           MockAzureOpenAiEmbeddingClient.lastEmbedCall = { request, requestConfig };
           const errorToThrow = MockAzureOpenAiEmbeddingClient.embedError;
           if (errorToThrow) {
@@ -449,7 +454,7 @@ describe("SAPAIEmbeddingModel", () => {
 
       const lastCall = await getLastEmbedCallForApi(api);
       expect(lastCall?.requestConfig).toBeDefined();
-      expect((lastCall?.requestConfig as Record<string, unknown>).headers).toMatchObject({
+      expect(lastCall?.requestConfig?.headers).toMatchObject({
         "x-custom": "embed-value",
       });
     });
@@ -466,7 +471,7 @@ describe("SAPAIEmbeddingModel", () => {
 
       const lastCall = await getLastEmbedCallForApi(api);
       expect(lastCall?.requestConfig?.signal).toBe(abortController.signal);
-      expect((lastCall?.requestConfig as Record<string, unknown>).headers).toMatchObject({
+      expect(lastCall?.requestConfig?.headers).toMatchObject({
         "x-custom": "embed-value",
       });
     });

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -14,6 +14,7 @@ import { clearStrategyCaches } from "./sap-ai-strategy.js";
 import { computeNoCache } from "./strategy-utils.js";
 
 interface CapturedRequestConfig {
+  [key: string]: unknown;
   headers?: Record<string, string>;
   signal?: AbortSignal;
 }

--- a/src/sap-ai-language-model.test.ts
+++ b/src/sap-ai-language-model.test.ts
@@ -13,6 +13,11 @@ import { SAPAILanguageModel } from "./sap-ai-language-model";
 import { clearStrategyCaches } from "./sap-ai-strategy.js";
 import { computeNoCache } from "./strategy-utils.js";
 
+interface CapturedRequestConfig {
+  headers?: Record<string, string>;
+  signal?: AbortSignal;
+}
+
 vi.mock("@sap-ai-sdk/orchestration", () => {
   class MockOrchestrationClient {
     static chatCompletionError: Error | undefined;
@@ -596,11 +601,11 @@ describe("SAPAILanguageModel", () => {
   interface MockClientInterface {
     lastConstructorConfig?: unknown;
     lastRequest: unknown;
-    lastRequestConfig: unknown;
+    lastRequestConfig: CapturedRequestConfig | undefined;
     lastStreamAbortSignal: unknown;
     lastStreamConfig?: unknown;
     lastStreamRequest: unknown;
-    lastStreamRequestConfig?: unknown;
+    lastStreamRequestConfig?: CapturedRequestConfig;
     setChatCompletionError?: (error: Error) => void;
     setChatCompletionResponse?: (response: unknown) => void;
     setStreamChunks?: (chunks: unknown[]) => void;
@@ -613,13 +618,13 @@ describe("SAPAILanguageModel", () => {
     const { OrchestrationClient } = await import("@sap-ai-sdk/orchestration");
     const client = OrchestrationClient as unknown as {
       lastChatCompletionRequest: unknown;
-      lastChatCompletionRequestConfig: unknown;
+      lastChatCompletionRequestConfig: CapturedRequestConfig | undefined;
       lastConstructorCall:
         undefined | { config: unknown; deploymentConfig: unknown; destination: unknown };
       lastStreamAbortSignal: unknown;
       lastStreamConfig: unknown;
       lastStreamRequest: unknown;
-      lastStreamRequestConfig: unknown;
+      lastStreamRequestConfig: CapturedRequestConfig | undefined;
       setChatCompletionError?: (error: Error) => void;
       setChatCompletionResponse?: (response: unknown) => void;
       setStreamChunks?: (chunks: unknown[]) => void;
@@ -649,10 +654,10 @@ describe("SAPAILanguageModel", () => {
     const client = AzureOpenAiChatClient as unknown as {
       lastConstructorCall: undefined | { destination: unknown; modelDeployment: unknown };
       lastRunRequest: unknown;
-      lastRunRequestConfig: unknown;
+      lastRunRequestConfig: CapturedRequestConfig | undefined;
       lastStreamAbortSignal: unknown;
       lastStreamRequest: unknown;
-      lastStreamRequestConfig: unknown;
+      lastStreamRequestConfig: CapturedRequestConfig | undefined;
       setChatCompletionError?: (error: Error) => void;
       setChatCompletionResponse?: (response: unknown) => void;
       setStreamChunks?: (chunks: unknown[]) => void;
@@ -1302,7 +1307,7 @@ describe("SAPAILanguageModel", () => {
         const MockClient = await getMockClientForApi(api);
         expect(MockClient.lastRequestConfig).toBeDefined();
         expect(MockClient.lastRequestConfig).toHaveProperty("headers");
-        expect((MockClient.lastRequestConfig as Record<string, unknown>).headers).toMatchObject({
+        expect(MockClient.lastRequestConfig?.headers).toMatchObject({
           "x-custom": "value",
         });
       });
@@ -1321,7 +1326,7 @@ describe("SAPAILanguageModel", () => {
         const MockClient = await getMockClientForApi(api);
         expect(MockClient.lastRequestConfig).toBeDefined();
         expect(MockClient.lastRequestConfig).toHaveProperty("signal", controller.signal);
-        expect((MockClient.lastRequestConfig as Record<string, unknown>).headers).toMatchObject({
+        expect(MockClient.lastRequestConfig?.headers).toMatchObject({
           "x-custom": "value",
         });
       });
@@ -1344,9 +1349,7 @@ describe("SAPAILanguageModel", () => {
 
         const MockClient = await getMockClientForApi(api);
         expect(MockClient.lastStreamRequestConfig).toBeDefined();
-        expect(
-          (MockClient.lastStreamRequestConfig as Record<string, unknown>).headers,
-        ).toMatchObject({
+        expect(MockClient.lastStreamRequestConfig?.headers).toMatchObject({
           "x-custom": "stream-value",
         });
       });

--- a/src/sap-ai-provider-v2.ts
+++ b/src/sap-ai-provider-v2.ts
@@ -70,7 +70,8 @@ export interface SAPAIProviderSettings {
    *
    * See the "Note on `requestConfig`" section under `SAPAIProviderSettings` in
    * `API_REFERENCE.md` for the full SAP AI Core `AI-*` header guidance.
-   * @see {@link https://sap.github.io/ai-sdk/docs/js/getting-started SAP Cloud SDK for AI (JS)}
+   * @see {@link https://sap.github.io/ai-sdk/docs/js/getting-started | SAP Cloud SDK for AI (JS)}
+   * @see {@link https://github.com/jerome-benoit/sap-ai-provider/blob/main/API_REFERENCE.md#requestconfig-note | Note on `requestConfig` (API_REFERENCE.md)}
    */
   readonly requestConfig?: CustomRequestConfig;
 

--- a/src/sap-ai-provider-v2.ts
+++ b/src/sap-ai-provider-v2.ts
@@ -60,9 +60,25 @@ export interface SAPAIProviderSettings {
   readonly name?: string;
 
   /**
-   * Custom request configuration forwarded to the underlying SAP AI SDK client on every call.
-   * Use `requestConfig.headers` to pass service-specific HTTP headers (e.g. `AI-Object-Store-Secret-Name`).
-   * The `signal` property is ignored here — use the AI SDK `abortSignal` option instead.
+   * Custom request configuration forwarded to the underlying SAP AI SDK client on every call
+   * created from this provider.
+   *
+   * Scope: provider-level only. Not overridable via `providerOptions['sap-ai']`; create a
+   * separate provider instance when you need per-request variation.
+   *
+   * Common uses:
+   * - `requestConfig.headers` — service-specific HTTP headers. SAP AI Core recognises
+   *   `AI-Object-Store-Secret-Name` (feedback service; identifies the pre-registered object
+   *   store secret used to write inference feedback). Prefer the `resourceGroup` option
+   *   over the `AI-Resource-Group` header.
+   * - `requestConfig.params` / `requestConfig.timeout` — plain axios-style knobs.
+   *
+   * Portability: `httpAgent`, `httpsAgent`, `proxy`, and `adapter` are Node-only and are
+   * silently ignored on Edge / Cloudflare Workers runtimes.
+   *
+   * Abort semantics: the AI SDK `abortSignal` option always wins over any `signal` set on
+   * `requestConfig`; the latter is dropped before the request is forwarded.
+   * @see {@link https://sap.github.io/ai-sdk/docs/js SAP AI SDK for JavaScript}
    */
   readonly requestConfig?: CustomRequestConfig;
 

--- a/src/sap-ai-provider-v2.ts
+++ b/src/sap-ai-provider-v2.ts
@@ -60,25 +60,17 @@ export interface SAPAIProviderSettings {
   readonly name?: string;
 
   /**
-   * Custom request configuration forwarded to the underlying SAP AI SDK client on every call
-   * created from this provider.
+   * Custom request configuration forwarded to the underlying SAP AI SDK client on every
+   * call created from this provider.
    *
-   * Scope: provider-level only. Not overridable via `providerOptions['sap-ai']`; create a
-   * separate provider instance when you need per-request variation.
+   * Provider-level only (not overridable per-call via `providerOptions['sap-ai']`). The
+   * AI SDK `abortSignal` option always wins over any `signal` on `requestConfig`; the
+   * latter is dropped before the request is forwarded. Node-only knobs (`httpAgent`,
+   * `httpsAgent`) are silently ignored on Edge / Cloudflare Workers runtimes.
    *
-   * Common uses:
-   * - `requestConfig.headers` — service-specific HTTP headers. SAP AI Core recognises
-   *   `AI-Object-Store-Secret-Name` (feedback service; identifies the pre-registered object
-   *   store secret used to write inference feedback). Prefer the `resourceGroup` option
-   *   over the `AI-Resource-Group` header.
-   * - `requestConfig.params` / `requestConfig.timeout` — plain axios-style knobs.
-   *
-   * Portability: `httpAgent`, `httpsAgent`, `proxy`, and `adapter` are Node-only and are
-   * silently ignored on Edge / Cloudflare Workers runtimes.
-   *
-   * Abort semantics: the AI SDK `abortSignal` option always wins over any `signal` set on
-   * `requestConfig`; the latter is dropped before the request is forwarded.
-   * @see {@link https://sap.github.io/ai-sdk/docs/js SAP AI SDK for JavaScript}
+   * See the "Note on `requestConfig`" section under `SAPAIProviderSettings` in
+   * `API_REFERENCE.md` for the full SAP AI Core `AI-*` header guidance.
+   * @see {@link https://sap.github.io/ai-sdk/docs/js/getting-started SAP Cloud SDK for AI (JS)}
    */
   readonly requestConfig?: CustomRequestConfig;
 
@@ -118,7 +110,7 @@ export interface SAPAIProviderV2 extends ProviderV2 {
  * @param options.destination - Custom SAP Cloud SDK destination configuration.
  * @param options.logLevel - Log level for SAP Cloud SDK loggers (`'debug'`, `'info'`, `'warn'`, `'error'`).
  * @param options.name - Provider name used as key in `providerOptions` (default: `'sap-ai'`).
- * @param options.requestConfig - Custom request configuration forwarded to the SAP AI SDK client on every call.
+ * @param options.requestConfig - Provider-level custom request configuration. See {@link SAPAIProviderSettings.requestConfig} for scope, portability, and abort semantics.
  * @param options.resourceGroup - SAP AI Core resource group (default: `'default'`).
  * @param options.warnOnAmbiguousConfig - Whether to warn when both deploymentId and resourceGroup are set.
  * @returns A configured SAP AI provider instance that can be used as a callable or via methods.

--- a/src/sap-ai-provider.ts
+++ b/src/sap-ai-provider.ts
@@ -80,25 +80,17 @@ export interface SAPAIProviderSettings {
   readonly name?: string;
 
   /**
-   * Custom request configuration forwarded to the underlying SAP AI SDK client on every call
-   * created from this provider.
+   * Custom request configuration forwarded to the underlying SAP AI SDK client on every
+   * call created from this provider.
    *
-   * Scope: provider-level only. Not overridable via `providerOptions['sap-ai']`; create a
-   * separate provider instance when you need per-request variation.
+   * Provider-level only (not overridable per-call via `providerOptions['sap-ai']`). The
+   * AI SDK `abortSignal` option always wins over any `signal` on `requestConfig`; the
+   * latter is dropped before the request is forwarded. Node-only knobs (`httpAgent`,
+   * `httpsAgent`) are silently ignored on Edge / Cloudflare Workers runtimes.
    *
-   * Common uses:
-   * - `requestConfig.headers` — service-specific HTTP headers. SAP AI Core recognises
-   *   `AI-Object-Store-Secret-Name` (feedback service; identifies the pre-registered object
-   *   store secret used to write inference feedback). Prefer the `resourceGroup` option
-   *   over the `AI-Resource-Group` header.
-   * - `requestConfig.params` / `requestConfig.timeout` — plain axios-style knobs.
-   *
-   * Portability: `httpAgent`, `httpsAgent`, `proxy`, and `adapter` are Node-only and are
-   * silently ignored on Edge / Cloudflare Workers runtimes.
-   *
-   * Abort semantics: the AI SDK `abortSignal` option always wins over any `signal` set on
-   * `requestConfig`; the latter is dropped before the request is forwarded.
-   * @see {@link https://sap.github.io/ai-sdk/docs/js SAP AI SDK for JavaScript}
+   * See the "Note on `requestConfig`" section under `SAPAIProviderSettings` in
+   * `API_REFERENCE.md` for the full SAP AI Core `AI-*` header guidance.
+   * @see {@link https://sap.github.io/ai-sdk/docs/js/getting-started SAP Cloud SDK for AI (JS)}
    */
   readonly requestConfig?: CustomRequestConfig;
 
@@ -125,7 +117,7 @@ export interface SAPAIProviderSettings {
  * @param options.destination - Custom SAP Cloud SDK destination configuration.
  * @param options.logLevel - Log level for SAP Cloud SDK loggers (`'debug'`, `'info'`, `'warn'`, `'error'`).
  * @param options.name - Provider name used as key in `providerOptions` (default: `'sap-ai'`).
- * @param options.requestConfig - Custom request configuration forwarded to the SAP AI SDK client on every call.
+ * @param options.requestConfig - Provider-level custom request configuration. See {@link SAPAIProviderSettings.requestConfig} for scope, portability, and abort semantics.
  * @param options.resourceGroup - SAP AI Core resource group (default: `'default'`).
  * @param options.warnOnAmbiguousConfig - Whether to warn when both deploymentId and resourceGroup are set.
  * @returns A configured SAP AI provider instance that can be used as a callable or via methods.

--- a/src/sap-ai-provider.ts
+++ b/src/sap-ai-provider.ts
@@ -80,9 +80,25 @@ export interface SAPAIProviderSettings {
   readonly name?: string;
 
   /**
-   * Custom request configuration forwarded to the underlying SAP AI SDK client on every call.
-   * Use `requestConfig.headers` to pass service-specific HTTP headers (e.g. `AI-Object-Store-Secret-Name`).
-   * The `signal` property is ignored here — use the AI SDK `abortSignal` option instead.
+   * Custom request configuration forwarded to the underlying SAP AI SDK client on every call
+   * created from this provider.
+   *
+   * Scope: provider-level only. Not overridable via `providerOptions['sap-ai']`; create a
+   * separate provider instance when you need per-request variation.
+   *
+   * Common uses:
+   * - `requestConfig.headers` — service-specific HTTP headers. SAP AI Core recognises
+   *   `AI-Object-Store-Secret-Name` (feedback service; identifies the pre-registered object
+   *   store secret used to write inference feedback). Prefer the `resourceGroup` option
+   *   over the `AI-Resource-Group` header.
+   * - `requestConfig.params` / `requestConfig.timeout` — plain axios-style knobs.
+   *
+   * Portability: `httpAgent`, `httpsAgent`, `proxy`, and `adapter` are Node-only and are
+   * silently ignored on Edge / Cloudflare Workers runtimes.
+   *
+   * Abort semantics: the AI SDK `abortSignal` option always wins over any `signal` set on
+   * `requestConfig`; the latter is dropped before the request is forwarded.
+   * @see {@link https://sap.github.io/ai-sdk/docs/js SAP AI SDK for JavaScript}
    */
   readonly requestConfig?: CustomRequestConfig;
 

--- a/src/sap-ai-provider.ts
+++ b/src/sap-ai-provider.ts
@@ -90,7 +90,8 @@ export interface SAPAIProviderSettings {
    *
    * See the "Note on `requestConfig`" section under `SAPAIProviderSettings` in
    * `API_REFERENCE.md` for the full SAP AI Core `AI-*` header guidance.
-   * @see {@link https://sap.github.io/ai-sdk/docs/js/getting-started SAP Cloud SDK for AI (JS)}
+   * @see {@link https://sap.github.io/ai-sdk/docs/js/getting-started | SAP Cloud SDK for AI (JS)}
+   * @see {@link https://github.com/jerome-benoit/sap-ai-provider/blob/main/API_REFERENCE.md#requestconfig-note | Note on `requestConfig` (API_REFERENCE.md)}
    */
   readonly requestConfig?: CustomRequestConfig;
 

--- a/src/sap-ai-settings.ts
+++ b/src/sap-ai-settings.ts
@@ -232,7 +232,7 @@ export interface SAPAIEmbeddingSettings {
  *
  * Model availability depends on tenant configuration and region.
  * Common values include: `'gpt-4.1'`, `'gpt-4.1-mini'`, `'anthropic--claude-4.5-sonnet'`, `'gemini-2.5-pro'`.
- * @see {@link https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/models-and-scenarios-in-generative-ai-hub|SAP AI Core Models}
+ * @see {@link https://help.sap.com/docs/sap-ai-core/sap-ai-core-service-guide/models-and-scenarios-in-generative-ai-hub | SAP AI Core Models}
  */
 export type SAPAIModelId = ChatModel;
 


### PR DESCRIPTION
## Description

Follow-up to #165 addressing the remaining documentation, DX, and test-hygiene nits from the review that the code-level fixes in that PR left as follow-ups. No behavioural change; docs, tests, and one additive barrel type re-export.

### Documentation

- **`SAPAIProviderSettings.requestConfig` JSDoc** (V3 + V2 mirrored) — expanded to explicitly state:
  - provider-level scope (not overridable via `providerOptions['sap-ai']`)
  - Node-only fields (`httpAgent`, `httpsAgent`, `proxy`, `adapter`) silently ignored on Edge / Cloudflare Workers
  - abort semantics (AI SDK `abortSignal` always wins over `requestConfig.signal`)
  - SAP AI Core header guidance with feedback-service context for `AI-Object-Store-Secret-Name` (per the [SAP AI SDK JS orchestration types](https://github.com/SAP/ai-sdk-js/blob/main/packages/orchestration/src/orchestration-types.ts)) and the `AI-Resource-Group` note.
- **`API_REFERENCE.md`** — added a Notes block after the property table covering scope, portability, abort semantics, and an `AI-*` header table with source link; plus a second example demonstrating a non-header use case (`timeout: 30_000`).
- **`README.md`** — expanded the `requestConfig` bullet with scope hint and a link to `API_REFERENCE.md` for portability caveats.
- **`ARCHITECTURE.md`** — refreshed the "Request Cancellation" snippets that previously showed the pre-PR pattern (`{ signal: options.abortSignal } | undefined`) to reflect the post-#165 flow via `mergeRequestConfig`.

### Public API surface

- Re-export `CustomRequestConfig` type from `@sap-ai-sdk/core` in both `src/index.ts` and `src/index-v2.ts` so consumers can annotate `requestConfig` without pulling in an extra dependency. Additive, non-breaking.

### Tests

- Widened the mock `requestConfig` shape in `sap-ai-embedding-model.test.ts` and `sap-ai-language-model.test.ts` from `{ signal?: AbortSignal }` to `{ headers?: Record<string, string>; signal?: AbortSignal }`, eliminating the three `as Record<string, unknown>` casts introduced by the new assertions in #165. Same 1306 tests, no test removed.
- V2 tests intentionally left as-is — the `(model as any).internalModel.xxx` pattern is used ~30 times across the V2 test files (pre-existing accepted repo pattern for facade→internal introspection); replacing it in isolation would create asymmetry.

## Type of Change

- [ ] Bug fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Documentation update
- [x] Refactoring (no functional changes)
- [ ] Dependency update

## Checklist

- [x] `npm run type-check && npm run test && npm run prettier-check && npm run lint`
- [x] `npm run build && npm run check-build && npm run build:v2 && npm run check-build:v2`
- [x] Documentation updated
- [x] Tests unchanged in count, three unsafe casts removed
- [x] Follows existing code style

## Related

Refs #165.